### PR TITLE
Add `typescript` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module.exports = {
 | --- | --- |
 | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], and more. |
 | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
+| [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. Includes recommended rules from [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import#typescript), [prettier/@typescript-eslint], and more.
 
 ## Custom rules
 
@@ -69,6 +70,9 @@ Note that we prefer to upstream our custom lint rules to third-party eslint plug
 [eslint-plugin-filenames]: https://github.com/selaux/eslint-plugin-filenames
 [eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import
 [prettier]: https://prettier.io/
+[typescript]: lib/config/typescript.js
+[@typescript-eslint/parser]: https://www.npmjs.com/package/@typescript-eslint/parser
+[prettier/@typescript-eslint]: https://github.com/prettier/eslint-config-prettier/blob/master/%40typescript-eslint.js
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module.exports = {
 | --- | --- |
 | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], and more. |
 | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
-| [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. Includes recommended rules from [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import#typescript), [prettier/@typescript-eslint], and more.
+| [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
 
 ## Custom rules
 
@@ -71,8 +71,6 @@ Note that we prefer to upstream our custom lint rules to third-party eslint plug
 [eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import
 [prettier]: https://prettier.io/
 [typescript]: lib/config/typescript.js
-[@typescript-eslint/parser]: https://www.npmjs.com/package/@typescript-eslint/parser
-[prettier/@typescript-eslint]: https://github.com/prettier/eslint-config-prettier/blob/master/%40typescript-eslint.js
 
 ## License
 

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -10,13 +10,14 @@ module.exports = {
     'prettier/@typescript-eslint',
     'plugin:import/typescript',
   ],
-  plugins: ['square'],
+  plugins: ['filenames', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
-    'no-debugger': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
+
+    'filenames/match-regex': ['error', '^.?[a-z0-9-]+(.d)?$'], // Kebab-case.
 
     // import rules:
     'import/group-exports': 'error',

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -5,6 +5,7 @@
 module.exports = {
   extends: [
     require.resolve('./base'),
+    'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
     'plugin:import/typescript',

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// This configuration is intended for use in TypeScript projects.
+
+module.exports = {
+  extends: [
+    require.resolve('./base'),
+    'plugin:@typescript-eslint/recommended',
+    'prettier/@typescript-eslint',
+    'plugin:import/typescript',
+  ],
+  plugins: ['square'],
+  rules: {
+    // Optional eslint rules:
+    'no-console': 'error',
+    'no-debugger': 'error',
+    'sort-keys': ['error', 'asc', { natural: true }],
+    'sort-vars': 'error',
+
+    // import rules:
+    'import/group-exports': 'error',
+    'import/order': [
+      'error',
+      {
+        alphabetize: { order: 'asc' },
+        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+      },
+    ],
+
+    // Our custom rules:
+    'square/no-focused-tests': 'error',
+    'square/use-call-count-test-assert': 'error',
+  },
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+  ],
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,5 +21,6 @@ module.exports = {
   configs: {
     base: require('./config/base'),
     ember: require('./config/ember'),
+    typescript: require('./config/typescript'),
   },
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "eslint",
     "eslint-config",
     "eslint-plugin",
-    "linter"
+    "linter",
+    "typescript"
   ],
   "license": "Apache-2.0",
   "repository": {
@@ -29,6 +30,7 @@
     "node": ">= 10"
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.25.0",
     "camelcase": "^5.3.1",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-ember": "^7.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,10 +202,48 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/json-schema@^7.0.3":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@typescript-eslint/eslint-plugin@^2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.25.0.tgz#0b60917332f20dcff54d0eb9be2a9e9f4c9fbd02"
+  integrity sha512-W2YyMtjmlrOjtXc+FtTelVs9OhuR6OlYc4XKIslJ8PUJOqgYYAPRJhAqkYRQo3G4sjvG8jSodsNycEn4W2gHUw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.25.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz#13691c4fe368bd377b1e5b1e4ad660b220bf7714"
+  integrity sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.25.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/typescript-estree@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz#b790497556734b7476fa7dd3fa539955a5c79e2c"
+  integrity sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -2575,10 +2613,17 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tslib@^1.10.0, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Our team has a framework-less, browser-based project that uses TypeScript. We'd like to use `eslint-plugin-square` to drive our linting going forward. This PR is most of our current configuration minus overlaps with `base`. (We'll continue to use plugins specific to our test framework and assertion library.)