### PR TITLE
Drop Node 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 ## Requirements
 
 * [ESLint](https://eslint.org/) `>= 5.16`
-* [Node.js](https://nodejs.org/) `>= 10`
+* [Node.js](https://nodejs.org/) `10.* || >= 12`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/square/eslint-plugin-square.git"
   },
   "engines": {
-    "node": ">= 10"
+    "node": "10.* || >= 12"
   },
   "dependencies": {
     "camelcase": "^5.3.1",


### PR DESCRIPTION
Node 11 is end-of-life.

This is technically a breaking change. I originally intended to include this was the v13 release.