### PR TITLE
Allow PascalCase component filenames in `react` config

### DIFF
--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -13,4 +13,12 @@ module.exports = {
     // Require kebab-case file names
     'filenames/match-regex': ['error', '^.?[a-z0-9-]+(.d)?$'],
   },
+  overrides: [
+    {
+      files: ['src/components/**/*'],
+      rules: {
+        'filenames/match-regex': ['error', '^([A-Z][a-z.]+)+(.[tj]sx?)?$'],
+      },
+    },
+  ],
 };


### PR DESCRIPTION
React component file names are typically defined in PascalCase to match the exported variable names, which are also PascalCase in an effort to avoid potentially ambiguity due to conflicts with HTML element names.