### PR TITLE
Tweak filename regexes and other rules in `react` config

### DIFF
--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -6,18 +6,27 @@ module.exports = {
   extends: [require.resolve('./base'), 'plugin:react/recommended'],
   plugins: ['filenames'],
   rules: {
+    'filenames/match-regex': ['error', '^[a-z0-9]+[a-z0-9-\\.]*$'],
+    'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+    'import/extensions': 'off',
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
-
-    // Require kebab-case file names
-    'filenames/match-regex': ['error', '^.?[a-z0-9-]+(.d)?$'],
   },
   overrides: [
     {
       files: ['src/components/**/*'],
       rules: {
-        'filenames/match-regex': ['error', '^([A-Z][a-z.]+)+(.[tj]sx?)?$'],
+        'filenames/match-regex': [
+          'error',
+          '^([A-Z]+[a-z0-9\\.]*)+(.[tj]sx?)?$',
+        ],
+      },
+    },
+    {
+      files: ['src/setupTests.*'],
+      rules: {
+        'filenames/match-regex': 'off',
       },
     },
   ],


### PR DESCRIPTION
These changes represent overrides and rules specified in my team ESLint configuration that would probably be of more use on a horizontal scale. No rush on the merge!

-Update kebab-case file name regular expression to accept multiple `.` instances and disallow capitalized first letter
-Alphabetize rule property names
-Allow non-declarative arrow functions
-Allow file extensions for imports due to webpack support/requirement
-Update component file name regular expression to allow multiple `.` instances
-Add file name override for `setupTests` file required by create-react-app API