### PR TITLE
Disable `no-useless-constructor` rule in `typescript` config

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -42,5 +42,13 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
       },
     },
+    {
+      files: ['*.ts'],
+      rules: {
+        // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'error',
+      },
+    },
   ],
 };


### PR DESCRIPTION
tl;dr `eslint/no-useless-constructor` doesn't understand all TypeScript syntax 🤯

as you can see in [this example repo](https://github.com/maxbeatty/example-eslint/commit/65b2499bfadfaf2119fae1e90d0866ce2cb50b35), `declare class Animal` syntax from TypeScript causes a thrown error in `no-useless-constructor` preventing eslint from completing.

```ts
declare class Animal {
    constructor(age: number);
    makeNoise: () => string;
}
```

[overriding the rule and replacing with @typescript-eslint/no-useless-constructor variant](https://github.com/maxbeatty/example-eslint/commit/dd886d002f44a4ecb93a130ee8b31793a1680641#diff-1dc6ee56b778cd91e0327b52aaeaa1b9R8-R9) (which is more robust for TypeScript) allows eslint to complete and properly report useless constructors.

[using this fork](https://github.com/maxbeatty/example-eslint/commit/82701512ff957d118b534b97c8f607eeb1ff39e3#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R18) yields the same results

[linked](https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762) in the override is documentation about where this originated 