### PR TITLE
Standardize filename regexes

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -2,6 +2,8 @@
 
 // This configuration is intended for use with JavaScript applications.
 
+const filenames = require('../utils/filenames');
+
 module.exports = {
   extends: [
     'eslint:recommended',
@@ -11,7 +13,7 @@ module.exports = {
   env: {
     es6: true,
   },
-  plugins: ['es', 'eslint-comments', 'import', 'prettier'],
+  plugins: ['es', 'eslint-comments', 'import', 'filenames', 'prettier'],
   rules: {
     // Optional eslint rules:
     'array-callback-return': 'error',
@@ -82,6 +84,8 @@ module.exports = {
 
     // eslint-comments:
     'eslint-comments/no-unused-disable': 'error',
+
+    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Prettier:
     'prettier/prettier': [

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -2,8 +2,6 @@
 
 // This configuration is intended for use with JavaScript applications.
 
-const filenames = require('../utils/filenames');
-
 module.exports = {
   extends: [
     'eslint:recommended',
@@ -13,7 +11,7 @@ module.exports = {
   env: {
     es6: true,
   },
-  plugins: ['es', 'eslint-comments', 'import', 'filenames', 'prettier'],
+  plugins: ['es', 'eslint-comments', 'import', 'prettier'],
   rules: {
     // Optional eslint rules:
     'array-callback-return': 'error',
@@ -84,8 +82,6 @@ module.exports = {
 
     // eslint-comments:
     'eslint-comments/no-unused-disable': 'error',
-
-    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Prettier:
     'prettier/prettier': [

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -6,7 +6,7 @@ const ASYNC_EMBER_TEST_HELPERS = require('../utils/async-ember-test-helpers');
 
 module.exports = {
   extends: [require.resolve('./base'), 'plugin:ember/recommended'],
-  plugins: ['ember', 'filenames', 'square'],
+  plugins: ['ember', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
@@ -21,8 +21,6 @@ module.exports = {
     'ember/no-replace-test-comments': 'error',
     'ember/no-unnecessary-service-injection-argument': 'error',
     'ember/route-path-style': 'error',
-
-    'filenames/match-regex': ['error', '^.?[a-z0-9-]+(.d)?$'], // Kebab-case.
 
     // Our custom rules:
     'square/no-assert-ok-find': 'error',

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -3,10 +3,11 @@
 // This configuration is intended for use in Ember applications.
 
 const ASYNC_EMBER_TEST_HELPERS = require('../utils/async-ember-test-helpers');
+const filenames = require('../utils/filenames');
 
 module.exports = {
   extends: [require.resolve('./base'), 'plugin:ember/recommended'],
-  plugins: ['ember', 'square'],
+  plugins: ['ember', 'filenames', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
@@ -21,6 +22,8 @@ module.exports = {
     'ember/no-replace-test-comments': 'error',
     'ember/no-unnecessary-service-injection-argument': 'error',
     'ember/route-path-style': 'error',
+
+    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Our custom rules:
     'square/no-assert-ok-find': 'error',

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -9,10 +9,13 @@ module.exports = {
   plugins: ['filenames'],
   rules: {
     'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
-    'import/extensions': 'off',
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
+
+    'filenames/match-regex': ['error', filenames.regex.kebab],
+
+    'import/extensions': 'off',
   },
   overrides: [
     {

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+const filenames = require('../utils/filenames');
+
 module.exports = {
   extends: [require.resolve('./base'), 'plugin:react/recommended'],
   plugins: ['filenames'],
@@ -16,10 +18,7 @@ module.exports = {
     {
       files: ['src/components/**/*'],
       rules: {
-        'filenames/match-regex': [
-          'error',
-          '^([A-Z]+[a-z0-9\\.]*)+(.[tj]sx?)?$',
-        ],
+        'filenames/match-regex': ['error', filenames.regex.pascal],
       },
     },
     {

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -6,7 +6,6 @@ module.exports = {
   extends: [require.resolve('./base'), 'plugin:react/recommended'],
   plugins: ['filenames'],
   rules: {
-    'filenames/match-regex': ['error', '^[a-z0-9]+[a-z0-9-\\.]*$'],
     'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
     'import/extensions': 'off',
     'no-console': 'error',

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -10,14 +10,12 @@ module.exports = {
     'prettier/@typescript-eslint',
     'plugin:import/typescript',
   ],
-  plugins: ['filenames', 'square'],
+  plugins: ['square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
-
-    'filenames/match-regex': ['error', '^.?[a-z0-9-]+(.d)?$'], // Kebab-case.
 
     // import rules:
     'import/group-exports': 'error',

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -2,6 +2,8 @@
 
 // This configuration is intended for use in TypeScript projects.
 
+const filenames = require('../utils/filenames');
+
 module.exports = {
   extends: [
     require.resolve('./base'),
@@ -10,12 +12,14 @@ module.exports = {
     'prettier/@typescript-eslint',
     'plugin:import/typescript',
   ],
-  plugins: ['square'],
+  plugins: ['filenames', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
+
+    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // import rules:
     'import/group-exports': 'error',

--- a/lib/utils/filenames.js
+++ b/lib/utils/filenames.js
@@ -1,7 +1,12 @@
 'use strict';
 
+// filenames/match-regex ignores file extension so you can too in your regex
+// https://github.com/selaux/eslint-plugin-filenames/blob/1.3.0/lib/rules/match-regex.js#L29
+// https://github.com/selaux/eslint-plugin-filenames/blob/1.3.0/lib/common/parseFilename.js#L10
+
 module.exports = {
   regex: {
     kebab: '^[a-z0-9]+[a-z0-9-\\.]*$',
+    pascal: '^([A-Z]+[a-z0-9\\.]*)+$',
   },
 };

--- a/lib/utils/filenames.js
+++ b/lib/utils/filenames.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  regex: {
+    kebab: '^[a-z0-9]+[a-z0-9-\\.]*$',
+  },
+};

--- a/lib/utils/filenames.js
+++ b/lib/utils/filenames.js
@@ -6,7 +6,7 @@
 
 module.exports = {
   regex: {
-    kebab: '^[a-z0-9]+[a-z0-9-\\.]*$',
+    kebab: '^.?[a-z0-9]+[a-z0-9-\\.]+$',
     pascal: '^([A-Z]+[a-z0-9\\.]*)+$',
   },
 };

--- a/tests/lib/utils/filenames.js
+++ b/tests/lib/utils/filenames.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const filenames = require('../../../lib/utils/filenames');
+const assert = require('assert');
+
+describe('filenames', () => {
+  // filenames/match-regex ignores file extension so these tests also do
+  // https://github.com/selaux/eslint-plugin-filenames/blob/1.3.0/lib/rules/match-regex.js#L29
+  // https://github.com/selaux/eslint-plugin-filenames/blob/1.3.0/lib/common/parseFilename.js#L10
+  describe('regex', () => {
+    it('supports kebab case', () => {
+      const re = new RegExp(filenames.regex.kebab);
+
+      [
+        'foo',
+        'foo-bar',
+        'foo-bar-baz',
+        '1fish',
+        '1fish-2fish',
+        'type.d',
+        'index.test',
+        'apple.stories',
+      ].forEach((t) => assert.ok(re.test(t), `expected '${t}' to be ok`));
+
+      ['snake_case', 'camelCase', 'PascalCase'].forEach((t) =>
+        assert.ok(!re.test(t), `expted ${t} to NOT be ok`)
+      );
+    });
+  });
+});

--- a/tests/lib/utils/filenames.js
+++ b/tests/lib/utils/filenames.js
@@ -23,7 +23,19 @@ describe('filenames', () => {
       ].forEach((t) => assert.ok(re.test(t), `expected '${t}' to be ok`));
 
       ['snake_case', 'camelCase', 'PascalCase'].forEach((t) =>
-        assert.ok(!re.test(t), `expted ${t} to NOT be ok`)
+        assert.ok(!re.test(t), `expected ${t} to NOT be ok`)
+      );
+    });
+
+    it('supports pascal case', () => {
+      const re = new RegExp(filenames.regex.pascal);
+
+      ['App', 'PascalCase', 'FooBarBaz', 'App.test'].forEach((t) =>
+        assert.ok(re.test(t), `expected '${t}' to be ok`)
+      );
+
+      ['simple', 'snake_case', 'kebab-case', 'dot.case'].forEach((t) =>
+        assert.ok(!re.test(t), `expected ${t} to NOT be ok`)
       );
     });
   });

--- a/tests/lib/utils/filenames.js
+++ b/tests/lib/utils/filenames.js
@@ -20,6 +20,8 @@ describe('filenames', () => {
         'type.d',
         'index.test',
         'apple.stories',
+        '.eslintrc',
+        '.template-lintrc',
       ].forEach((t) => assert.ok(re.test(t), `expected '${t}' to be ok`));
 
       ['snake_case', 'camelCase', 'PascalCase'].forEach((t) =>


### PR DESCRIPTION
Currently, the regex used by `ember` and `typescript` only allows filenames like `foo-bar.d.js`. The `react` regex allows for multiple dots and expanded suffixes such as `apple.stories.test.jsx`. This PR abstracts the regex being used by the three configurations making it testable.

As a bonus, I tested the `react` component pascal regex.