### PR TITLE
Update each rule doc to mention what config enables the rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ module.exports = {
 
 ## Configurations
 
-| Name | Description |
-| --- | --- |
-| [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], and more. |
-| [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
-| [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
-| [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
+|     | Name | Description |
+| --- | --- | --- |
+| | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], and more. |
+| :fire: | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
+| | [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
+| | [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
 
 Rules enabled by these configurations should meet the following criteria:
 
@@ -44,23 +44,23 @@ Rules enabled by these configurations should meet the following criteria:
 
 ## Custom rules
 
-| Rule | Category | Configuration Enabled In | Fixable? |
-| --- | --- | --- | --- |
-| [no-async](docs/rules/no-async.md) | JavaScript | N/A | |
-| [no-for-of](docs/rules/no-for-of.md) | JavaScript | N/A | |
-| [no-undef](docs/rules/no-undef.md) | JavaScript | N/A | :wrench: |
-| [require-await-function](docs/rules/require-await-function.md) | JavaScript | [ember] | :wrench: |
-| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md) | Ember | N/A | |
-| [no-modifying-immutable-properties](docs/rules/no-modifying-immutable-properties.md) | Ember | N/A | :wrench: |
-| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | Ember | [ember] | |
-| [no-assert-ok-find](docs/rules/no-assert-ok-find.md) | Testing | [ember] | |
-| [no-focused-tests](docs/rules/no-focused-tests.md) | Testing | [ember] | |
-| [no-lazy-arrow-functions](docs/rules/no-lazy-arrow-functions.md) | Testing | [ember] | :wrench: |
-| [no-missing-tests](docs/rules/no-missing-tests.md) | Testing | N/A | |
-| [no-test-expect-assertion-count](docs/rules/no-test-expect-assertion-count.md) | Testing | [ember] | |
-| [no-test-return-value](docs/rules/no-test-return-value.md) | Testing | [ember] | |
-| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md) | Testing | [ember] | :wrench: |
-| [use-ember-find](docs/rules/use-ember-find.md) | Testing | [ember] | :wrench: |
+| Rule | Category | Config | Fixable? |
+| :--- | :------- | :----- | :------- |
+| [no-async](docs/rules/no-async.md) | JavaScript | | |
+| [no-for-of](docs/rules/no-for-of.md) | JavaScript | | |
+| [no-undef](docs/rules/no-undef.md) | JavaScript | | :wrench: |
+| [require-await-function](docs/rules/require-await-function.md) | JavaScript | :fire: | :wrench: |
+| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md) | Ember | | |
+| [no-modifying-immutable-properties](docs/rules/no-modifying-immutable-properties.md) | Ember | | :wrench: |
+| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | Ember | :fire: | |
+| [no-assert-ok-find](docs/rules/no-assert-ok-find.md) | Testing | :fire: | |
+| [no-focused-tests](docs/rules/no-focused-tests.md) | Testing | :fire: | |
+| [no-lazy-arrow-functions](docs/rules/no-lazy-arrow-functions.md) | Testing | :fire: | :wrench: |
+| [no-missing-tests](docs/rules/no-missing-tests.md) | Testing | | |
+| [no-test-expect-assertion-count](docs/rules/no-test-expect-assertion-count.md) | Testing | :fire: | |
+| [no-test-return-value](docs/rules/no-test-return-value.md) | Testing | :fire: | |
+| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md) | Testing | :fire: | :wrench: |
+| [use-ember-find](docs/rules/use-ember-find.md) | Testing | :fire: | :wrench: |
 
 Note that we prefer to upstream our custom lint rules to third-party eslint plugins whenever possible. The rules that still remain here are typically here because:
 

--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -1,5 +1,7 @@
 # no-assert-ok-find
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 Ember's `find('.selector')` test helper function always returns an array, even when no elements match. As a result, `assert.ok(find('.selector'))` will always pass, even if no elements are found, as an empty array is still truthy.
 
 ## Rule Details

--- a/docs/rules/no-focused-tests.md
+++ b/docs/rules/no-focused-tests.md
@@ -1,5 +1,7 @@
 # no-focused-tests
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 [only](https://api.qunitjs.com/QUnit/only) can be useful when debugging tests, but merging a test case with it can prevent CI from running other tests.
 
 This rule handles the following [qunit-bdd](https://github.com/square/qunit-bdd) test hooks:

--- a/docs/rules/no-lazy-arrow-functions.md
+++ b/docs/rules/no-lazy-arrow-functions.md
@@ -1,5 +1,7 @@
 # no-lazy-arrow-functions (fixable)
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 When people use arrow functions in their [qunit-bdd](https://github.com/square/qunit-bdd) `lazy` test variables, they often run into issues where they try to use `this` for the test context and it doesn't work.
 
 ## Examples

--- a/docs/rules/no-test-expect-assertion-count.md
+++ b/docs/rules/no-test-expect-assertion-count.md
@@ -1,5 +1,7 @@
 # no-test-expect-assertion-count
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 Prevents the use of `expect(n)` to count the number of expected assertions in tests. This rule is in place because `expect(n)` can be a burden to maintain and exposes bad patterns such as nested promise chains.
 
 ## Examples

--- a/docs/rules/no-test-return-value.md
+++ b/docs/rules/no-test-return-value.md
@@ -1,5 +1,7 @@
 # no-test-return-value
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 This rule disallows test functions with return values.
 
 For asynchronous tests, use async/await instead of returning a promise.

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -1,5 +1,7 @@
 # no-translation-key-interpolation
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 Using string interpolation for constructing translation keys makes it difficult to search for them to determine where and if they are used.
 
 ## Rule Details

--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -1,5 +1,7 @@
 # require-await-function (fixable)
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 Some functions are asynchronous and you may want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help you achieve this.
 
 ## Rule Details

--- a/docs/rules/use-call-count-test-assert.md
+++ b/docs/rules/use-call-count-test-assert.md
@@ -1,5 +1,7 @@
 # use-call-count-test-assert (fixable)
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 Using `callCount` rather than the other shortcut count helpers (such as `calledOnce`, `notCalled`) allows the test runner to show the actual number of times the spy was called.
 
 ## Rule Details

--- a/docs/rules/use-ember-find.md
+++ b/docs/rules/use-ember-find.md
@@ -1,5 +1,7 @@
 # use-ember-find (fixable)
 
+:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+
 It is preferred to use Ember test helpers like `find(selector)` instead of jQuery for selecting elements in tests.
 
 ## Rule Details

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -5,8 +5,11 @@ const { readdirSync, readFileSync } = require('fs');
 const { join } = require('path');
 const assert = require('assert');
 const rules = require('../lib').rules;
+const configEmber = require('../lib/config/ember');
 
 const RULE_NAMES = Object.keys(rules);
+const RULE_NAMES_EMBER = new Set(Object.keys(configEmber.rules));
+RULE_NAMES_EMBER.add('square/require-await-function'); // This rule is enabled in an override.
 
 describe('rules setup is correct', function () {
   it('should have a list of exported rules and rules directory that match', function () {
@@ -46,6 +49,9 @@ describe('rules setup is correct', function () {
   });
 
   it('should have the right contents (title, examples, fixable notice) for each rule documentation file', function () {
+    const CONFIG_MSG_EMBER =
+      ':fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.';
+
     RULE_NAMES.forEach((ruleName) => {
       const rule = rules[ruleName];
       const path = join(__dirname, '..', 'docs', 'rules', `${ruleName}.md`);
@@ -63,6 +69,15 @@ describe('rules setup is correct', function () {
         assert.ok(
           !file.includes('(fixable)'),
           'does not include fixable notice'
+        );
+      }
+
+      if (RULE_NAMES_EMBER.has(`square/${ruleName}`)) {
+        assert.ok(file.includes(CONFIG_MSG_EMBER), 'has `ember` config notice');
+      } else {
+        assert.ok(
+          !file.includes(CONFIG_MSG_EMBER),
+          'does not have `ember` config notice'
         );
       }
     });


### PR DESCRIPTION
Matches the eslint core plugin rule docs (example: https://eslint.org/docs/rules/no-extra-semi).

This makes it much easier to gain a complete picture of the rule by looking at its rule doc (without depending on the overall README.md).

And adds a test to ensure the docs are correct.

Based on a change I made: https://github.com/ember-cli/eslint-plugin-ember/pull/759