### PR TITLE
Export filename regex utils

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,4 +24,7 @@ module.exports = {
     react: require('./config/react'),
     typescript: require('./config/typescript'),
   },
+  utils: {
+    filenames: require('./utils/filenames'),
+  },
 };


### PR DESCRIPTION
These need to be exported so that consumers can conveniently use the regexes in any of their `filenames/match-regex` overrides.

Follow-up to #30.

CC: @ghaagsma 