### PR TITLE
Kebab-case filename restrictions should allow single-character filenames

### DIFF
--- a/lib/utils/filenames.js
+++ b/lib/utils/filenames.js
@@ -6,7 +6,7 @@
 
 module.exports = {
   regex: {
-    kebab: '^.?[a-z0-9]+[a-z0-9-\\.]+$',
+    kebab: '^.?[a-z0-9]+[a-z0-9-\\.]*$',
     pascal: '^([A-Z]+[a-z0-9\\.]*)+$',
   },
 };

--- a/tests/lib/utils/filenames.js
+++ b/tests/lib/utils/filenames.js
@@ -12,6 +12,7 @@ describe('filenames', () => {
       const re = new RegExp(filenames.regex.kebab);
 
       [
+        't',
         'foo',
         'foo-bar',
         'foo-bar-baz',
@@ -32,7 +33,7 @@ describe('filenames', () => {
     it('supports pascal case', () => {
       const re = new RegExp(filenames.regex.pascal);
 
-      ['App', 'PascalCase', 'FooBarBaz', 'App.test'].forEach((t) =>
+      ['A', 'App', 'PascalCase', 'FooBarBaz', 'App.test'].forEach((t) =>
         assert.ok(re.test(t), `expected '${t}' to be ok`)
       );
 


### PR DESCRIPTION
Example: `t.js`

CC: @ghaagsma 