### PR TITLE
Move `sort-vars` to `base` config

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -75,6 +75,7 @@ module.exports = {
     'require-atomic-updates': 'error',
     'require-await': 'error',
     'spaced-comment': ['error', 'always', { markers: ['*', '!'] }],
+    'sort-vars': 'error',
     yoda: 'error',
 
     // es:

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -11,7 +11,6 @@ module.exports = {
     'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
-    'sort-vars': 'error',
 
     'filenames/match-regex': ['error', filenames.regex.kebab],
 

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -17,7 +17,6 @@ module.exports = {
     // Optional eslint rules:
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
-    'sort-vars': 'error',
 
     'filenames/match-regex': ['error', filenames.regex.kebab],
 


### PR DESCRIPTION
BREAKING CHANGE for next major release.

This rule is autofixable and thus easy to adopt. It's generally a minor but nice change.

https://eslint.org/docs/rules/sort-vars