### PR TITLE
Enable eslint-plugin-unicorn recommended rules in `base` config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,8 @@ module.exports = {
     './lib/config/base.js',
     'plugin:eslint-plugin/all',
     'plugin:node/recommended',
-    'plugin:unicorn/recommended',
   ],
-  plugins: ['eslint-plugin', 'unicorn'],
+  plugins: ['eslint-plugin'],
   env: {
     commonjs: true,
   },
@@ -23,10 +22,6 @@ module.exports = {
       },
     ],
     'eslint-plugin/test-case-property-ordering': 'off',
-
-    // Unicorn:
-    'unicorn/no-fn-reference-in-iterator': 'off',
-    'unicorn/no-null': 'off'
   },
   overrides: [
     {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module.exports = {
 
 |     | Name | Description |
 | --- | --- | --- |
-| | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], and more. |
+| | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], [eslint-plugin-unicorn], and more. |
 | :fire: | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
 | | [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
 | | [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
@@ -76,6 +76,7 @@ Note that we prefer to upstream our custom lint rules to third-party eslint plug
 [eslint-plugin-eslint-comments]: https://github.com/mysticatea/eslint-plugin-eslint-comments
 [eslint-plugin-filenames]: https://github.com/selaux/eslint-plugin-filenames
 [eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import
+[eslint-plugin-unicorn]: https://github.com/sindresorhus/eslint-plugin-unicorn
 [prettier]: https://prettier.io/
 [react]: lib/config/react.js
 [typescript]: lib/config/typescript.js

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -8,12 +8,21 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:eslint-comments/recommended',
+    'plugin:unicorn/recommended',
     'prettier',
+    'prettier/unicorn',
   ],
   env: {
     es6: true,
   },
-  plugins: ['es', 'eslint-comments', 'filenames', 'import', 'prettier'],
+  plugins: [
+    'es',
+    'eslint-comments',
+    'filenames',
+    'import',
+    'prettier',
+    'unicorn',
+  ],
   rules: {
     // Optional eslint rules:
     'array-callback-return': 'error',
@@ -118,5 +127,18 @@ module.exports = {
     'import/no-unused-modules': 'error',
     'import/no-useless-path-segments': 'error',
     'import/no-webpack-loader-syntax': 'error',
+
+    // Unicorn rules:
+    'unicorn/catch-error-name': 'off', // We use many different valid names for our try/catch errors.
+    'unicorn/consistent-function-scoping': 'off', // We have a lot of functions in different scopes.
+    'unicorn/no-fn-reference-in-iterator': 'off', // We use this a lot.
+    'unicorn/no-null': 'off', // We use a lot of `null`.
+    'unicorn/prefer-add-event-listener': 'off', // The autofixer can be unsafe.
+    'unicorn/prefer-flat-map': 'off', // Wait until enough browsers support `flatMap()`.
+    'unicorn/prefer-node-append': 'off', // This incorrectly autofixes `append()` on non-DOM-nodes.
+    'unicorn/prefer-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
+    'unicorn/prefer-query-selector': 'off', // The autofixer can be unsafe.
+    'unicorn/prefer-text-content': 'off', // The autofixer can be unsafe.
+    'unicorn/prevent-abbreviations': 'off', // Probably not a good fit for us as we use many abbreviations.
   },
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-unicorn": "19.0.1",
     "espree": "^6.2.1",
     "estraverse": "^5.1.0",
     "prettier": "^2.0.5"
@@ -49,7 +50,6 @@
     "eslint": "6.8.0",
     "eslint-plugin-eslint-plugin": "2.2.1",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-unicorn": "19.0.1",
     "lerna-changelog": "1.0.1",
     "markdownlint-cli": "0.23.0",
     "mocha": "7.1.2",


### PR DESCRIPTION
This plugin has a large variety of amazing lint rules, especially for adopting new JavaScript syntax/functions, and most of them are autofixable. I've really enjoyed using them in some of my applications already.

Note that we are already using this plugin internally ourselves.

https://github.com/sindresorhus/eslint-plugin-unicorn