### PR TITLE
Enforce kebab-case filenames in `base` configuration

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -2,6 +2,8 @@
 
 // This configuration is intended for use with JavaScript applications.
 
+const filenames = require('../utils/filenames');
+
 module.exports = {
   extends: [
     'eslint:recommended',
@@ -11,7 +13,7 @@ module.exports = {
   env: {
     es6: true,
   },
-  plugins: ['es', 'eslint-comments', 'import', 'prettier'],
+  plugins: ['es', 'eslint-comments', 'filenames', 'import', 'prettier'],
   rules: {
     // Optional eslint rules:
     'array-callback-return': 'error',
@@ -82,6 +84,8 @@ module.exports = {
 
     // eslint-comments:
     'eslint-comments/no-unused-disable': 'error',
+
+    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Prettier:
     'prettier/prettier': [

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -3,11 +3,10 @@
 // This configuration is intended for use in Ember applications.
 
 const ASYNC_EMBER_TEST_HELPERS = require('../utils/async-ember-test-helpers');
-const filenames = require('../utils/filenames');
 
 module.exports = {
   extends: [require.resolve('./base'), 'plugin:ember/recommended'],
-  plugins: ['ember', 'filenames', 'square'],
+  plugins: ['ember', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
@@ -22,8 +21,6 @@ module.exports = {
     'ember/no-replace-test-comments': 'error',
     'ember/no-unnecessary-service-injection-argument': 'error',
     'ember/route-path-style': 'error',
-
-    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Our custom rules:
     'square/no-assert-ok-find': 'error',

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -13,8 +13,6 @@ module.exports = {
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
 
-    'filenames/match-regex': ['error', filenames.regex.kebab],
-
     'import/extensions': 'off',
   },
   overrides: [

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -2,8 +2,6 @@
 
 // This configuration is intended for use in TypeScript projects.
 
-const filenames = require('../utils/filenames');
-
 module.exports = {
   extends: [
     require.resolve('./base'),
@@ -12,14 +10,12 @@ module.exports = {
     'prettier/@typescript-eslint',
     'plugin:import/typescript',
   ],
-  plugins: ['filenames', 'square'],
+  plugins: ['square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
     'sort-keys': ['error', 'asc', { natural: true }],
     'sort-vars': 'error',
-
-    'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // import rules:
     'import/group-exports': 'error',


### PR DESCRIPTION
BREAKING CHANGE: base will now error when filenames do not match kebab case

follow up to https://github.com/square/eslint-plugin-square/pull/30#discussion_r403385481