### PR TITLE
Update warning for unused-vars in Typescript

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -49,7 +49,10 @@ module.exports = {
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762
         'no-useless-constructor': 'off',
-        '@typescript-eslint/no-unused-vars': ['warning', { 'argsIgnorePattern': '^_' }],
+        '@typescript-eslint/no-unused-vars': [
+          'warning', // Warning used to align with @typescript-eslint/recommended
+          { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
+        ],
         '@typescript-eslint/no-useless-constructor': 'error',
       },
     },

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -49,6 +49,7 @@ module.exports = {
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762
         'no-useless-constructor': 'off',
+        '@typescript-eslint/no-unused-vars': ['warning', { 'argsIgnorePattern': '^_' }],
         '@typescript-eslint/no-useless-constructor': 'error',
       },
     },


### PR DESCRIPTION
Current state: `@typescript-eslint/no-unused-vars` warns when there is an unused parameter, even when it starts with an underscore.

Proposal: For Typescript, allow for unused-var parameters as long as they start with an `_`. The use of an underscore aligns with Typescript's implementation for skipping unused params: https://github.com/Microsoft/TypeScript/issues/9458

Documentation for eslint: https://eslint.org/docs/rules/no-unused-vars#argsignorepattern