### PR TITLE
Enable `catchRouterMicrolib` option on `ember/no-private-routing-service` rule

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -12,6 +12,12 @@ module.exports = {
     // Optional eslint rules:
     'no-console': 'error',
 
+    // Recommended Ember rules with custom options:
+    'ember/no-private-routing-service': [
+      'error',
+      { catchRouterMicrolib: true },
+    ],
+
     // Ember Octane rules:
     'ember/classic-decorator-hooks': 'error',
     'ember/classic-decorator-no-classic-methods': 'error',


### PR DESCRIPTION
https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-private-routing-service.md