### PR TITLE
Turn off unicorn/prefer-optional-catch-binding rule

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -139,6 +139,7 @@ module.exports = {
     'unicorn/prefer-flat-map': 'off', // Wait until enough browsers support `flatMap()`.
     'unicorn/prefer-node-append': 'off', // This incorrectly autofixes `append()` on non-DOM-nodes.
     'unicorn/prefer-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
+    'unicorn/prefer-optional-catch-binding': 'off', // Wait until enough browsers support this.
     'unicorn/prefer-query-selector': 'off', // The autofixer can be unsafe.
     'unicorn/prefer-text-content': 'off', // The autofixer can be unsafe.
     'unicorn/prevent-abbreviations': 'off', // Probably not a good fit for us as we use many abbreviations.


### PR DESCRIPTION
This is a new rule from eslint-plugin-unicorn v20: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-optional-catch-binding.md

Turn it off because:

1. Avoid it becoming a breaking change in our next minor release.
2. This is fairly new JavaScript syntax still: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch

Follow-up to: https://github.com/square/eslint-plugin-square/pull/70