### PR TITLE
Add .markdownlintignore

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+node_modules

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint '**/*.md' -i CHANGELOG.md -i node_modules",
+    "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint .",
     "preversion": "yarn test && yarn lint",
     "test": "nyc --all --check-coverage mocha --recursive tests"


### PR DESCRIPTION
This should prevent IDEs from autofixing or highlighting violations in files like CHANGELOG.md (which are autogenerated).

.markdownlintignore will be respected by anyone running markdownlint, regardless of whether they use our npm/yarn scripts to run it.