### PR TITLE
Add new rule `no-restricted-files`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Rules enabled by these configurations should meet the following criteria:
 | :--- | :------- | :----- | :------- |
 | [no-async](docs/rules/no-async.md) | JavaScript | | |
 | [no-for-of](docs/rules/no-for-of.md) | JavaScript | | |
+| [no-restricted-files](docs/rules/no-restricted-files.md) | JavaScript | | |
 | [no-undef](docs/rules/no-undef.md) | JavaScript | | :wrench: |
 | [require-await-function](docs/rules/require-await-function.md) | JavaScript | :fire: | :wrench: |
 | [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md) | Ember | | |

--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -1,0 +1,19 @@
+# no-restricted-files
+
+This rule can be used to disallow files at certain file paths.
+
+## Examples
+
+For example, we may want to disallow unscoped/unnested components, and instead require that each component is nested or scoped within a folder.
+
+Regexp: `app/components/[^/]+$`
+
+Disallows this unscoped component: `app/components/my-component.js`
+
+Allows this scoped component: `app/components/scope/my-component.js`
+
+## Configuration
+
+* object[] -- containing the following properties:
+  * string[] -- `paths` -- list of regexp file paths to disallow
+  * string -- `error` -- optional custom error message to display for these disallowed file paths

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-lazy-arrow-functions': require('./rules/no-lazy-arrow-functions'),
     'no-missing-tests': require('./rules/no-missing-tests'),
     'no-modifying-immutable-properties': require('./rules/no-modifying-immutable-properties'),
+    'no-restricted-files': require('./rules/no-restricted-files'),
     'no-test-expect-assertion-count': require('./rules/no-test-expect-assertion-count'),
     'no-test-return-value': require('./rules/no-test-return-value'),
     'no-translation-key-interpolation': require('./rules/no-translation-key-interpolation'),

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const DEFAULT_ERROR_MESSAGE = 'Files matching this path are not allowed.';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow files with a path matching a specific regexp',
+      category: 'JavaScript',
+      url:
+        'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/no-restricted-files.md',
+    },
+    schema: {
+      type: 'array',
+      minItems: 1,
+      uniqueItems: true,
+      items: {
+        type: 'object',
+        required: ['paths'],
+        properties: {
+          error: {
+            type: 'string',
+          },
+          paths: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+
+  DEFAULT_ERROR_MESSAGE,
+
+  create(context) {
+    return {
+      Program(node) {
+        const match = context.options.find((option) =>
+          option.paths.some((path) => context.getFilename().match(path))
+        );
+        if (match) {
+          context.report({
+            node,
+            message: match.error || DEFAULT_ERROR_MESSAGE,
+          });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/no-restricted-files.js
+++ b/tests/lib/rules/no-restricted-files.js
@@ -1,0 +1,64 @@
+const rule = require('../../../lib/rules/no-restricted-files');
+const RuleTester = require('eslint').RuleTester;
+
+const { DEFAULT_ERROR_MESSAGE } = rule;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015,
+  },
+});
+
+const REGEXP_DISALLOW_UNSCOPED_COMPONENTS = 'app/components/[^/]+$';
+
+const FILEPATH_UNSCOPED_COMPONENT = 'app/components/my-component.js';
+const FILEPATH_SCOPED_COMPONENT = 'app/components/scope/my-component.js';
+
+ruleTester.run('no-restricted-files', rule, {
+  valid: [
+    {
+      code: 'const x = 123;',
+      options: [{ paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS] }],
+      filename: FILEPATH_SCOPED_COMPONENT,
+    },
+  ],
+  invalid: [
+    {
+      code: 'const x = 123;',
+      options: [{ paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS] }],
+      filename: FILEPATH_UNSCOPED_COMPONENT,
+      output: null,
+      errors: [{ message: DEFAULT_ERROR_MESSAGE, type: 'Program' }],
+    },
+    {
+      // With custom error message:
+      code: 'const x = 123;',
+      options: [
+        {
+          paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS],
+          error: 'No unscoped components.',
+        },
+      ],
+      filename: FILEPATH_UNSCOPED_COMPONENT,
+      output: null,
+      errors: [{ message: 'No unscoped components.', type: 'Program' }],
+    },
+    {
+      // With two objects passed.
+      code: 'const x = 123;',
+      options: [
+        {
+          paths: ['random-path'],
+        },
+        {
+          paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS],
+          error: 'No unscoped components.',
+        },
+      ],
+      filename: FILEPATH_UNSCOPED_COMPONENT,
+      output: null,
+      errors: [{ message: 'No unscoped components.', type: 'Program' }],
+    },
+  ],
+});


### PR DESCRIPTION
See rule documentation.

My use case: I'm planning to manually enable this rule in one of my large applications to disallow unscoped/unnested components in the top-level components folder. Over time, the top-level components folder can become littered with a long, disorganized list of components with unclear ownership.

Somewhat inspired by rules like [no-restricted-imports](https://eslint.org/docs/rules/no-restricted-imports).
