### PR TITLE
Rename `error` option to `message` in `no-restricted-files` rule

### DIFF
--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -16,4 +16,4 @@ Allows this scoped component: `app/components/scope/my-component.js`
 
 * object[] -- containing the following properties:
   * string[] -- `paths` -- list of regexp file paths to disallow
-  * string -- `error` -- optional custom error message to display for these disallowed file paths
+  * string -- `message` -- optional custom error message to display for these disallowed file paths

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -19,7 +19,7 @@ module.exports = {
         type: 'object',
         required: ['paths'],
         properties: {
-          error: {
+          message: {
             type: 'string',
           },
           paths: {
@@ -47,7 +47,7 @@ module.exports = {
         if (match) {
           context.report({
             node,
-            message: match.error || DEFAULT_ERROR_MESSAGE,
+            message: match.message || DEFAULT_ERROR_MESSAGE,
           });
         }
       },

--- a/tests/lib/rules/no-restricted-files.js
+++ b/tests/lib/rules/no-restricted-files.js
@@ -37,7 +37,7 @@ ruleTester.run('no-restricted-files', rule, {
       options: [
         {
           paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS],
-          error: 'No unscoped components.',
+          message: 'No unscoped components.',
         },
       ],
       filename: FILEPATH_UNSCOPED_COMPONENT,
@@ -53,7 +53,7 @@ ruleTester.run('no-restricted-files', rule, {
         },
         {
           paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS],
-          error: 'No unscoped components.',
+          message: 'No unscoped components.',
         },
       ],
       filename: FILEPATH_UNSCOPED_COMPONENT,


### PR DESCRIPTION
Better consistency with other `no-restricted-*` lint rules.

Rule has not been released yet. Follow-up to #80.