### PR TITLE
Add commented-out autofixer to `no-restricted-files` rule

### DIFF
--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -17,3 +17,7 @@ Allows this scoped component: `app/components/scope/my-component.js`
 * object[] -- containing the following properties:
   * string[] -- `paths` -- list of regexp file paths to disallow
   * string -- `message` -- optional custom error message to display for these disallowed file paths
+
+## Migration
+
+There's an autofixer in the rule implementation that can be uncommented as desired.

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -48,6 +48,13 @@ module.exports = {
           context.report({
             node,
             message: match.message || DEFAULT_ERROR_MESSAGE,
+            // Uncomment this autofixer to grandfather in existing files.
+            // fix(fixer) {
+            //   return fixer.insertTextBefore(
+            //     node,
+            //     '/* eslint square/no-restricted-files:"off" */\n'
+            //   );
+            // },
           });
         }
       },


### PR DESCRIPTION
Several of our rules have commented-out autofixers that can be used to grandfather in existing violations.