### PR TITLE
Add `filenames/match-exported` rule to `base` config

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -95,6 +95,8 @@ module.exports = {
     // eslint-comments:
     'eslint-comments/no-unused-disable': 'error',
 
+    // Filenames:
+    'filenames/match-exported': ['error', 'kebab'],
     'filenames/match-regex': ['error', filenames.regex.kebab],
 
     // Prettier:


### PR DESCRIPTION
https://github.com/selaux/eslint-plugin-filenames#matching-exported-values-match-exported

> Match the file name against the default exported value in the module. Files that dont have a default export will be ignored. The exports of index.js are matched against their parent directory.