### PR TITLE
Enable `no-assignment-of-untracked-properties-used-in-tracking-contexts` rule in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -22,6 +22,8 @@ module.exports = {
     'ember/classic-decorator-no-classic-methods': 'error',
 
     // Optional Ember rules:
+    'ember/no-assignment-of-untracked-properties-used-in-tracking-contexts':
+      'error',
     'ember/no-empty-attrs': 'error',
     'ember/no-proxies': 'error',
     'ember/no-replace-test-comments': 'error',


### PR DESCRIPTION
https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md