### PR TITLE
Only enable TypeScript linting for `.ts` files in `typescript` config

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -3,13 +3,7 @@
 // This configuration is intended for use in TypeScript projects.
 
 module.exports = {
-  extends: [
-    require.resolve('./base'),
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
-    'plugin:import/typescript',
-  ],
+  extends: [require.resolve('./base')],
   plugins: ['square'],
   rules: {
     // Optional eslint rules:
@@ -33,14 +27,13 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.js'],
-      rules: {
-        '@typescript-eslint/explicit-function-return-type': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
-      },
-    },
-    {
       files: ['*.ts'],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+        'prettier/@typescript-eslint',
+        'plugin:import/typescript',
+      ],
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762
         'no-useless-constructor': 'off',


### PR DESCRIPTION
ESLint 6+ supports using `extends` inside of `overrides`: https://eslint.org/blog/2019/06/eslint-v6.0.0-released

This prevents TypeScript lint rules from erroneously applying to JavaScript files.

Fixes #87.