### PR TITLE
Drop ESLint 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 
 ## Requirements
 
-* [ESLint](https://eslint.org/) `>= 5.16`
+* [ESLint](https://eslint.org/) `>= 6`
 * [Node.js](https://nodejs.org/) `10.* || 12.* || >= 14.*`
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "engines": {
     "node": "10.* || 12.* || >= 14.*"
   },
+  "peerDependencies": {
+    "eslint": ">= 6"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "camelcase": "^6.0.0",


### PR DESCRIPTION
Drop eslint 5 support (now that two newer versions are available: eslint 6 released 2019-06, eslint 7 released 2020-05).

It also helps that the ember-cli linting plugins have been deprecated (https://emberjs.github.io/rfcs/0121-remove-ember-cli-eslint.html) so pretty much everybody should be explicitly specifying eslint as a peer dependency at this point.

Fixes #86.