### PR TITLE
Stop testing under ESLint 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,4 @@ jobs:
     - run: yarn install --frozen-lockfile --non-interactive
     - run: yarn lint
     - run: yarn test
-    - run: yarn add --dev eslint@5 && yarn test
     - run: yarn add --dev eslint@6 && yarn test


### PR DESCRIPTION
Since we dropped ESLint 5 support: https://github.com/square/eslint-plugin-square/pull/130