### PR TITLE
Disable `filenames/match-exported` rule for certain Ember file types in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -61,5 +61,24 @@ module.exports = {
         ],
       },
     },
+    {
+      files: [
+        '{app,addon}/{components,controllers,routes,services}/**/*.{js,ts}',
+      ],
+      rules: {
+        /**
+         * Turn this rule off for these file types because it does not support Ember's blueprint generator naming convention.
+         *
+         * Example:
+         *
+         * Running this command:
+         *     ember generate component hello-world
+         * Produces a file with:
+         *     export default class HelloWorldComponent extends Component {}
+         * But this rule expects the class to be named "HelloWorld".
+         */
+        'filenames/match-exported': 'off',
+      },
+    },
   ],
 };


### PR DESCRIPTION
For a few Ember file types (components, controllers, etc), this rule does not support the naming convention used by Ember's blueprint generator command.

And unfortunately, the rule doesn't allow providing a custom transform to support the desired naming convention.

https://github.com/selaux/eslint-plugin-filenames#matching-exported-values-match-exported

CC: @raycohen @mongoose700