### PR TITLE
Disable `filenames/match-exported` rule for dummy apps / subapps in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -63,7 +63,7 @@ module.exports = {
     },
     {
       files: [
-        '{app,addon}/{components,controllers,routes,services}/**/*.{js,ts}',
+        '**/{app,addon}/{components,controllers,routes,services}/**/*.{js,ts}',
       ],
       rules: {
         /**


### PR DESCRIPTION
This ensures the rule is disabled in the dummy test app (i.e. `tests/dummy/app/controllers`) and inside in-repo addons (i.e. `lib/some-subapp/app/controllers`).