### PR TITLE
Member ordering rule to enforce public, protected, and private method order in classes

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -41,6 +41,26 @@ module.exports = {
           { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
+        '@typescript-eslint/member-ordering': [
+            'error',
+            {
+              'default': [
+                'public-static-field',
+                'protected-static-field',
+                'private-static-field',
+                'public-instance-field',
+                'protected-instance-field',
+                'private-instance-field',
+                'constructor',
+                'public-static-method',
+                'protected-static-method',
+                'private-static-method',
+                'public-instance-method',
+                'protected-instance-method',
+                'private-instance-method'
+              ]
+            }
+          ]
       },
     },
   ],


### PR DESCRIPTION
Force appropriate ordering within classes related to public, protected, and private fields and methods. This will ensure standardization of typescript classes, and make it obvious which methods of a class are publicly accessible, something that needs to be checked manually through code reviews and can be missed when methods are mixed with private and protected..

Considerations:
1. I put this as an error, since warnings are typically ignored. This however does mean that people who upgrade will have to clean up their files, which goes to point 2.
2. As of right now prettier will not automate this, meaning it has to be done manually. See the following for reasoning: https://github.com/prettier/prettier/issues/5412#issuecomment-437270581