### PR TITLE
Re-enable `unicorn/prefer-flat-map` rule in `base` config which was recently removed from eslint-plugin-unicorn's recommended config in v21.0.0

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -138,6 +138,7 @@ module.exports = {
     'unicorn/no-reduce': 'off', // We use a lot of `reduce`.
     'unicorn/no-useless-undefined': 'off', // We use a lot of `return undefined` to satisfy the `consistent-return` rule.
     'unicorn/prefer-add-event-listener': 'off', // The autofixer can be unsafe.
+    'unicorn/prefer-flat-map': 'error', // We polyfill `flatMap` to make it available for use.
     'unicorn/prefer-node-append': 'off', // This incorrectly autofixes `append()` on non-DOM-nodes.
     'unicorn/prefer-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
     'unicorn/prefer-query-selector': 'off', // The autofixer can be unsafe.


### PR DESCRIPTION
https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v21.0.0