### PR TITLE
Add eslint-plugin-qunit to `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -5,8 +5,13 @@
 const ASYNC_EMBER_TEST_HELPERS = require('../utils/async-ember-test-helpers');
 
 module.exports = {
-  extends: [require.resolve('./base'), 'plugin:ember/recommended'],
-  plugins: ['ember', 'square'],
+  extends: [
+    require.resolve('./base'),
+    'plugin:ember/recommended',
+    'plugin:qunit/recommended',
+    'plugin:qunit/two',
+  ],
+  plugins: ['ember', 'qunit', 'square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',
@@ -33,6 +38,16 @@ module.exports = {
     'ember/no-unnecessary-service-injection-argument': 'error',
     'ember/prefer-ember-test-helpers': 'error',
     'ember/route-path-style': 'error',
+
+    // QUnit rules:
+    'qunit/no-arrow-tests': 'error',
+    'qunit/no-compare-relation-boolean': ['error', { fixToNotOk: true }],
+    'qunit/no-global-assertions': 'off', // This incorrectly flags imported functions (including computed property macros like `equal`): https://github.com/platinumazure/eslint-plugin-qunit/issues/75
+    'qunit/no-global-module-test': 'off', // This incorrectly flags imported functions: https://github.com/platinumazure/eslint-plugin-qunit/issues/75
+    'qunit/no-global-stop-start': 'off', // This incorrectly flags imported functions: https://github.com/platinumazure/eslint-plugin-qunit/issues/75
+    'qunit/no-negated-ok': ['error', { fixToNotOk: true }],
+    'qunit/no-nested-tests': 'error',
+    'qunit/require-expect': ['error', 'never-except-zero'],
 
     // Our custom rules:
     'square/no-assert-ok-find': 'error',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-qunit": "^5.0.0",
     "eslint-plugin-react": "^7.21.2",
     "eslint-plugin-unicorn": "22.0.0",
     "espree": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-qunit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-5.0.0.tgz#2f33707b97f7b0a338c16378794e325550a1431b"
+  integrity sha512-F1AuwxsJ4YgSQztd3OZCNtM3DXpiDF9bpXbVCBcBU+8l5WOAAxfJHNYqP3tOhEEbIJPRkcTgk0SAJPYtdVjBmQ==
+
 eslint-plugin-react@^7.21.2:
   version "7.21.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz#3bd5d2c4c36d5a0428d0d6dda301ac9a84d681b2"


### PR DESCRIPTION
Ember uses QUnit tests.

Fixes #194.