### PR TITLE
Disable `checkInitOnly` and enable `checkNativeClasses` options on `ember/require-super-in-init rule` rule

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -22,6 +22,10 @@ module.exports = {
       { catchRouterMicrolib: true },
     ],
     'ember/no-get': ['error', { useOptionalChaining: true }],
+    'ember/require-super-in-init': [
+      'error',
+      { checkInitOnly: false, checkNativeClasses: true },
+    ],
 
     // Ember Octane rules:
     'ember/classic-decorator-hooks': 'error',


### PR DESCRIPTION
This makes the rule more strict and catch more potential issues. These options will be changed in the next major release of eslint-plugin-ember as well.

https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md