### PR TITLE
Turn off `unicorn/import-style` rule

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -133,6 +133,7 @@ module.exports = {
     // Unicorn rules:
     'unicorn/catch-error-name': 'off', // We use many different valid names for our try/catch errors.
     'unicorn/consistent-function-scoping': 'off', // We have a lot of functions in different scopes.
+    'unicorn/import-style': 'off', // Too noisy, not useful enough.
     'unicorn/no-fn-reference-in-iterator': 'off', // We use this a lot.
     'unicorn/no-null': 'off', // We use a lot of `null`.
     'unicorn/no-reduce': 'off', // We use a lot of `reduce`.


### PR DESCRIPTION
Too noisy:

```
Use default import for module `path`  unicorn/import-style
```

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/import-style.md