### PR TITLE
Split `strict` config out of `typescript` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Edit your `.eslintrc.js` configuration file to extend one of the available confi
 ```js
 module.exports = {
   plugins: ['square'],
-  extends: ['plugin:square/ember'], // Or other configuration.
+  extends: ['plugin:square/base'], // Or other configuration.
 };
 ```
 
@@ -34,6 +34,7 @@ module.exports = {
 | | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], [eslint-plugin-unicorn], and more. |
 | :fire: | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
 | | [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
+| | [strict] | A variety of stricter lint rules on top of `base`. |
 | | [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
 
 Rules enabled by these configurations should meet the following criteria:
@@ -74,6 +75,7 @@ Note that we prefer to upstream our custom lint rules to third-party eslint plug
 [eslint-plugin-unicorn]: https://github.com/sindresorhus/eslint-plugin-unicorn
 [prettier]: https://prettier.io/
 [react]: lib/config/react.js
+[strict]: lib/config/strict.js
 [typescript]: lib/config/typescript.js
 [@typescript-eslint/parser]: https://www.npmjs.com/package/@typescript-eslint/parser
 

--- a/lib/config/strict.js
+++ b/lib/config/strict.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  extends: [require.resolve('./base')],
+  plugins: ['square'],
+  rules: {
+    // Optional eslint rules:
+    'no-console': 'error',
+    'sort-keys': ['error', 'asc', { natural: true }],
+
+    // import rules:
+    'import/group-exports': 'error',
+    'import/order': [
+      'error',
+      {
+        alphabetize: { order: 'asc' },
+        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+      },
+    ],
+
+    // Our custom rules:
+    'square/use-call-count-test-assert': 'error',
+  },
+};

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -5,25 +5,7 @@
 module.exports = {
   extends: [require.resolve('./base')],
   plugins: ['square'],
-  rules: {
-    // Optional eslint rules:
-    'no-console': 'error',
-    'sort-keys': ['error', 'asc', { natural: true }],
-
-    // import rules:
-    'import/group-exports': 'error',
-    'import/order': [
-      'error',
-      {
-        alphabetize: { order: 'asc' },
-        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
-        'newlines-between': 'always',
-      },
-    ],
-
-    // Our custom rules:
-    'square/use-call-count-test-assert': 'error',
-  },
+  rules: {},
   overrides: [
     {
       files: ['*.ts'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     base: require('./config/base'),
     ember: require('./config/ember'),
     react: require('./config/react'),
+    strict: require('./config/strict'),
     typescript: require('./config/typescript'),
   },
   utils: {


### PR DESCRIPTION
Our `typescript` configuration should only enable the recommended TypeScript rules, and not be further opinionated, since TypeScript can be used with any type of application. I moved the unrelated linting into a new (experimental?) `strict` configuration.

This is an alternative to #241 (enabling TypeScript linting in the `base` configuration) which avoids the need to add a dependency on the large `typescript` package (which I'm also worried might have unexpected side effects in non-typescript apps or apps using a different version of typescript).