### PR TITLE
Enable @typescript-eslint/parser in `typescript` config

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -27,6 +27,7 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts'],
+      parser: '@typescript-eslint/parser',
       extends: [
         'plugin:@typescript-eslint/recommended',
         'prettier/@typescript-eslint',


### PR DESCRIPTION
By enabling the appropriate parser for TypeScript files in this configuration, we avoid the need for consumers to add an override to do so themselves.