### PR TITLE
Enable expected eslint-plugin-ember v10 linting in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -18,11 +18,6 @@ module.exports = {
 
     // Recommended Ember rules with custom options:
     'ember/no-get': ['error', { useOptionalChaining: true }],
-    'ember/no-side-effects': ['error', { checkPlainGetters: true }],
-    'ember/require-super-in-init': [
-      'error',
-      { checkInitOnly: false, checkNativeClasses: true },
-    ],
 
     // Ember Octane rules:
     'ember/classic-decorator-hooks': 'error',
@@ -34,6 +29,24 @@ module.exports = {
     'ember/no-replace-test-comments': 'error',
     'ember/no-unnecessary-service-injection-argument': 'error',
     'ember/route-path-style': 'error',
+
+    // Upcoming eslint-plugin-ember v10 additions (TODO: remove this section after this major version is released): https://github.com/ember-cli/eslint-plugin-ember/issues/960
+    'ember/no-empty-glimmer-component-classes': 'error',
+    'ember/no-get-with-default': [
+      'error',
+      { catchSafeObjects: true, catchUnsafeObjects: true },
+    ],
+    'ember/no-settled-after-test-helper': 'error',
+    'ember/no-shadow-route-definition': 'error',
+    'ember/no-side-effects': ['error', { checkPlainGetters: true }],
+    'ember/no-string-prototype-extensions': 'error',
+    'ember/no-test-support-import': 'error',
+    'ember/no-try-invoke': 'error',
+    'ember/require-super-in-init': [
+      'error',
+      { checkInitOnly: false, checkNativeClasses: true },
+    ],
+    'ember/require-valid-css-selector-in-test-helpers': 'error',
 
     // QUnit rules:
     'qunit/no-arrow-tests': 'error',


### PR DESCRIPTION
These are some of the lint rules/options that will be enabled in the upcoming eslint-plugin-ember v10 release. Once that release is published, we can remove this configuration.