### PR TITLE
Revert "Enable @typescript-eslint/parser in `typescript` config"

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -9,7 +9,6 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts'],
-      parser: '@typescript-eslint/parser',
       extends: [
         'plugin:@typescript-eslint/recommended',
         'prettier/@typescript-eslint',


### PR DESCRIPTION
Reverts square/eslint-plugin-square#248

This doesn't appear to work unless we were to add `@typescript-eslint/parser` as a dependency, which would thus require `typescript` itself as a dependency, which we don't want to do.

```
Error: Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc.js » plugin:square/typescript#overrides[0]': Cannot find module '@typescript-eslint/parser'
```