### PR TITLE
Enable `qunit/no-assert-equal-boolean` rule in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -28,6 +28,7 @@ module.exports = {
 
     // QUnit rules:
     'qunit/no-arrow-tests': 'error',
+    'qunit/no-assert-equal-boolean': 'error',
     'qunit/no-compare-relation-boolean': ['error', { fixToNotOk: true }],
     'qunit/no-global-assertions': 'off', // This incorrectly flags imported functions (including computed property macros like `equal`): https://github.com/platinumazure/eslint-plugin-qunit/issues/75
     'qunit/no-global-module-test': 'off', // This incorrectly flags imported functions: https://github.com/platinumazure/eslint-plugin-qunit/issues/75


### PR DESCRIPTION
https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal-boolean.md

Fixes #261.