### PR TITLE
Enable `qunit/no-global-*` rules in `ember` blueprint

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -30,9 +30,6 @@ module.exports = {
     'qunit/no-arrow-tests': 'error',
     'qunit/no-assert-equal-boolean': 'error',
     'qunit/no-compare-relation-boolean': ['error', { fixToNotOk: true }],
-    'qunit/no-global-assertions': 'off', // This incorrectly flags imported functions (including computed property macros like `equal`): https://github.com/platinumazure/eslint-plugin-qunit/issues/75
-    'qunit/no-global-module-test': 'off', // This incorrectly flags imported functions: https://github.com/platinumazure/eslint-plugin-qunit/issues/75
-    'qunit/no-global-stop-start': 'off', // This incorrectly flags imported functions: https://github.com/platinumazure/eslint-plugin-qunit/issues/75
     'qunit/no-negated-ok': ['error', { fixToNotOk: true }],
     'qunit/no-nested-tests': 'error',
     'qunit/require-expect': ['error', 'never-except-zero'],


### PR DESCRIPTION
The bug in these rules has been fixed.