### PR TITLE
Use `ecmaVersion` 2020

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,8 @@ module.exports = {
     'plugin:node/recommended',
   ],
   plugins: ['eslint-plugin'],
-  env: {
-    commonjs: true,
-  },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'script',
   },
   rules: {

--- a/tests/lib/rules/no-assert-ok-find.js
+++ b/tests/lib/rules/no-assert-ok-find.js
@@ -10,7 +10,7 @@ const NON_TEST_FILE_NAME = 'some-file.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-handlebar-interpolation.js
+++ b/tests/lib/rules/no-handlebar-interpolation.js
@@ -15,7 +15,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
     {
       code: "const foo = (bar) => { return '{{bar}}'; };",
       filename: 'foo/bar.js',
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
     },
     // Ignores file types that doesn't match default pattern
     {

--- a/tests/lib/rules/no-restricted-files.js
+++ b/tests/lib/rules/no-restricted-files.js
@@ -6,7 +6,7 @@ const { DEFAULT_ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
   },
 });
 

--- a/tests/lib/rules/no-test-return-value.js
+++ b/tests/lib/rules/no-test-return-value.js
@@ -10,7 +10,7 @@ const NON_TEST_FILE_NAME = 'some-file.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-translation-key-interpolation.js
+++ b/tests/lib/rules/no-translation-key-interpolation.js
@@ -7,7 +7,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/require-await-function.js
+++ b/tests/lib/rules/require-await-function.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/use-call-count-test-assert.js
+++ b/tests/lib/rules/use-call-count-test-assert.js
@@ -10,7 +10,7 @@ const NON_TEST_FILE_NAME = 'some-file.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/use-ember-find.js
+++ b/tests/lib/rules/use-ember-find.js
@@ -77,7 +77,7 @@ ruleTester.run('use-ember-find', rule, {
       filename: TEST_FILE_NAME,
       code: '$(`.some-${selector}`);', // eslint-disable-line no-template-curly-in-string
       output: "find(`.some-${selector}`, 'body');", // eslint-disable-line no-template-curly-in-string
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
 
@@ -98,7 +98,7 @@ ruleTester.run('use-ember-find', rule, {
       filename: TEST_FILE_NAME,
       code: 'jQuery(`.some-${selector}`);', // eslint-disable-line no-template-curly-in-string
       output: "find(`.some-${selector}`, 'body');", // eslint-disable-line no-template-curly-in-string
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
   ],

--- a/tests/lib/utils/is-literal.js
+++ b/tests/lib/utils/is-literal.js
@@ -44,5 +44,5 @@ describe('isLiteral', function () {
 });
 
 function p(code) {
-  return parse(code, { ecmaVersion: 6 }).body[0].expression;
+  return parse(code, { ecmaVersion: 2020 }).body[0].expression;
 }

--- a/tests/lib/utils/scope-reference-this.js
+++ b/tests/lib/utils/scope-reference-this.js
@@ -5,7 +5,7 @@ const parse = require('espree').parse;
 const scopeReferencesThis = require('../../../lib/utils/scope-references-this');
 
 function p(code) {
-  return parse(code, { ecmaVersion: 6 });
+  return parse(code, { ecmaVersion: 2020 });
 }
 
 describe('scopeReferencesThis', function () {


### PR DESCRIPTION
We can update to 2021 once we drop ESLint 6 support.