### PR TITLE
No longer need to manually enable unicorn flat rules

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -141,8 +141,6 @@ module.exports = {
     'unicorn/no-useless-undefined': 'off', // We use a lot of `return undefined` to satisfy the `consistent-return` rule.
     'unicorn/numeric-separators-style': 'off', // Too noisy for now.
     'unicorn/prefer-add-event-listener': 'off', // The autofixer can be unsafe.
-    'unicorn/prefer-array-flat': 'error', // We polyfill `flat` to make it available for use.
-    'unicorn/prefer-array-flat-map': 'error', // We polyfill `flatMap` to make it available for use.
     'unicorn/prefer-dom-node-append': 'off', // This incorrectly autofixes `append()` on non-DOM-nodes.
     'unicorn/prefer-dom-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
     'unicorn/prefer-dom-node-text-content': 'off', // The autofixer can be unsafe.


### PR DESCRIPTION
These are enabled by default as of #405 eslint-plugin-unicorn v32.