### PR TITLE
Use `meta.hasSuggestions` for suggestable rules to prepare for ESLint 8

### DIFF
--- a/lib/rules/no-assert-ok-find.js
+++ b/lib/rules/no-assert-ok-find.js
@@ -17,8 +17,8 @@ module.exports = {
         'disallow usage of `assert.ok(find(...))` as it will always pass',
       category: 'Ember Testing',
       url: 'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/no-assert-ok-find.md',
-      suggestion: true,
     },
+    hasSuggestions: true,
     schema: [],
   },
   create(context) {

--- a/lib/rules/no-test-return-value.js
+++ b/lib/rules/no-test-return-value.js
@@ -36,8 +36,8 @@ module.exports = {
       description: 'disallow test functions with a return value',
       category: 'Ember',
       url: 'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/no-test-return-value.md',
-      suggestion: true,
     },
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',


### PR DESCRIPTION
The change to require suggestable rules to have `meta.hasSuggestions` has been accepted and mentioned in the blog post for the upcoming ESLint 8 breaking changes. So we should adopt this change now to ensure we are compatible with ESLint 8 as soon as possible. The old property `meta.docs.suggestion` was unused anyway.

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property