### PR TITLE
Switch from github emojis to standard emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = {
 |     | Name | Description |
 | --- | --- | --- |
 | | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], [eslint-plugin-unicorn], and more. |
-| :fire: | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
+| 🔥 | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
 | | [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
 | | [strict] | A variety of stricter lint rules on top of `base`. |
 | | [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
@@ -47,15 +47,15 @@ Rules enabled by these configurations should meet the following criteria:
 
 | Rule | Category | Config | Fixable? | Suggestions? |
 | :--- | :------- | :----- | :------- | :----------- |
-| [no-assert-ok-find](docs/rules/no-assert-ok-find.md) | Ember Testing | :fire: | | 💡 |
+| [no-assert-ok-find](docs/rules/no-assert-ok-find.md) | Ember Testing | 🔥 | | 💡 |
 | [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md) | Ember | | | |
 | [no-missing-tests](docs/rules/no-missing-tests.md) | Testing | | | |
 | [no-restricted-files](docs/rules/no-restricted-files.md) | JavaScript | | | |
-| [no-test-return-value](docs/rules/no-test-return-value.md) | Testing | :fire: | | 💡 |
-| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | Ember | :fire: | | |
-| [require-await-function](docs/rules/require-await-function.md) | JavaScript | :fire: | :wrench: | |
-| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md) | Testing | :fire: | :wrench: | |
-| [use-ember-find](docs/rules/use-ember-find.md) | Ember Testing | :fire: | :wrench: | |
+| [no-test-return-value](docs/rules/no-test-return-value.md) | Testing | 🔥 | | 💡 |
+| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | Ember | 🔥 | | |
+| [require-await-function](docs/rules/require-await-function.md) | JavaScript | 🔥 | 🔧 | |
+| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md) | Testing | 🔥 | 🔧 | |
+| [use-ember-find](docs/rules/use-ember-find.md) | Ember Testing | 🔥 | 🔧 | |
 
 Note that we prefer to upstream our custom lint rules to third-party eslint plugins whenever possible. The rules that still remain here are typically here because:
 

--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -1,6 +1,6 @@
 # no-assert-ok-find
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-test-return-value.md
+++ b/docs/rules/no-test-return-value.md
@@ -1,6 +1,6 @@
 # no-test-return-value
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -1,6 +1,6 @@
 # no-translation-key-interpolation
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 Using string interpolation for constructing translation keys makes it difficult to search for them to determine where and if they are used.
 

--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -1,6 +1,6 @@
 # require-await-function (fixable)
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 Some functions are asynchronous and you may want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help you achieve this.
 

--- a/docs/rules/use-call-count-test-assert.md
+++ b/docs/rules/use-call-count-test-assert.md
@@ -1,6 +1,6 @@
 # use-call-count-test-assert (fixable)
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 Using `callCount` rather than the other shortcut count helpers (such as `calledOnce`, `notCalled`) allows the test runner to show the actual number of times the spy was called.
 

--- a/docs/rules/use-ember-find.md
+++ b/docs/rules/use-ember-find.md
@@ -1,6 +1,6 @@
 # use-ember-find (fixable)
 
-:fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
 
 It is preferred to use Ember test helpers like `find(selector)` instead of jQuery for selecting elements in tests.
 

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -70,7 +70,7 @@ describe('rules setup is correct', function () {
 
   describe('rule documentation files', function () {
     const CONFIG_MSG_EMBER =
-      ':fire: The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.';
+      '🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.';
 
     const HAS_SUGGESTIONS =
       '💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).';


### PR DESCRIPTION
Just use the standard ones for the fixable/config emojis.

Code editors like VSCode can't render `:white_check_mark:` but they can render standard emojis like ✅. Standard emojis are more universal and don't require special rendering engines. Easier to work with and preview locally.