### PR TITLE
Simplify CI dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,12 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          node_modules
-          .cache/yarn
-        key: eslint-plugin-square-${{ hashFiles('yarn.lock') }}
-        restore-keys: eslint-plugin-square
+        cache: 'yarn'
 
     - run: yarn install --frozen-lockfile --non-interactive
-      env:
-        YARN_CACHE_FOLDER: .cache/yarn
 
     - run: yarn lint
 


### PR DESCRIPTION
Follow-up to #463.

https://github.com/actions/setup-node#caching-packages-dependencies