### PR TITLE
Avoid crash when estraverse does not recognize node type during traversal

### DIFF
--- a/lib/utils/scope-references-this.js
+++ b/lib/utils/scope-references-this.js
@@ -29,6 +29,7 @@ function scopeReferencesThis(node) {
           break;
       }
     },
+    fallback: 'iteration',
   });
 
   return result;

--- a/tests/lib/utils/scope-reference-this.js
+++ b/tests/lib/utils/scope-reference-this.js
@@ -15,6 +15,10 @@ describe('scopeReferencesThis', function () {
       !scopeReferencesThis(p('"this"')),
       'the string "this" does not use this'
     );
+    assert.ok(
+      !scopeReferencesThis('class Foo { @someDecorator() someProp }'),
+      'Does not throw with node type (ClassProperty) not handled by estraverse'
+    );
   });
 
   it('can find nested `this`', function () {


### PR DESCRIPTION
https://github.com/estools/estraverse#example-usage

Same as this fix: https://github.com/ember-cli/eslint-plugin-ember/pull/1336