### PR TITLE
Switch to message IDs for reporting violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,6 @@ module.exports = {
   },
   rules: {
     'eslint-plugin/consistent-output': ['error', 'always'],
-    'eslint-plugin/prefer-message-ids': 'off',
     'eslint-plugin/require-meta-docs-url': [
       'error',
       {

--- a/lib/rules/no-assert-ok-find.js
+++ b/lib/rules/no-assert-ok-find.js
@@ -4,12 +4,7 @@ const isMemberExpression = require('../utils/is-member-expression');
 const isTestFile = require('../utils/is-test-file');
 const { ReferenceTracker } = require('eslint-utils');
 
-const ERROR_MESSAGE = '`assert.ok(find(...))` will always pass.';
-const SUGGEST_MESSAGE = 'Change to assert.equal(find(...).length, 1).';
-
 module.exports = {
-  ERROR_MESSAGE,
-  SUGGEST_MESSAGE,
   meta: {
     type: 'problem',
     docs: {
@@ -19,6 +14,11 @@ module.exports = {
       url: 'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/no-assert-ok-find.md',
     },
     schema: [],
+    messages: {
+      error: '`assert.ok(find(...))` will always pass.',
+      changeToAssertEqualFindLength:
+        'Change to assert.equal(find(...).length, 1).',
+    },
     hasSuggestions: true,
   },
   create(context) {
@@ -38,10 +38,10 @@ module.exports = {
           if (isAssertOk(parentNode)) {
             context.report({
               node: parentNode,
-              message: ERROR_MESSAGE,
+              messageId: 'error',
               suggest: [
                 {
-                  desc: SUGGEST_MESSAGE,
+                  messageId: 'changeToAssertEqualFindLength',
                   fix(fixer) {
                     const nodeFind = parentNode.arguments[0];
                     const nodeFindText = context

--- a/lib/rules/no-handlebar-interpolation.js
+++ b/lib/rules/no-handlebar-interpolation.js
@@ -23,6 +23,10 @@ module.exports = {
         additionalProperties: false,
       },
     ],
+    messages: {
+      error:
+        'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+    },
   },
 
   create(context) {
@@ -46,8 +50,7 @@ module.exports = {
       if (typeof value === 'string' && tripleStashRegex.test(value)) {
         context.report({
           node,
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
         });
       }
     }

--- a/lib/rules/no-missing-tests.js
+++ b/lib/rules/no-missing-tests.js
@@ -3,10 +3,7 @@
 const { existsSync } = require('fs');
 const path = require('path');
 
-const ERROR_MESSAGE = 'File is missing a corresponding test file.';
-
 module.exports = {
-  ERROR_MESSAGE,
   meta: {
     type: 'problem',
     docs: {
@@ -41,6 +38,9 @@ module.exports = {
         },
       },
     ],
+    messages: {
+      error: 'File is missing a corresponding test file.',
+    },
   },
   create(context) {
     const matchingLocation = context.options[0].find((location) =>
@@ -78,7 +78,7 @@ module.exports = {
         context.report({
           node,
           loc: { line: 1, column: 0 }, // Mark only first character as a violation to avoid annoyingly highlighting everything in the file as a violation.
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           // Uncomment this autofixer to grandfather in existing files that are missing tests.
           // fix(fixer) {
           //   return fixer.insertTextBefore(node, '/* eslint square/no-missing-tests: "off" */\n');

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const DEFAULT_ERROR_MESSAGE = 'Files matching this path are not allowed.';
-
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -33,9 +31,10 @@ module.exports = {
         additionalProperties: false,
       },
     },
+    messages: {
+      defaultError: 'Files matching this path are not allowed.',
+    },
   },
-
-  DEFAULT_ERROR_MESSAGE,
 
   create(context) {
     return {
@@ -46,7 +45,8 @@ module.exports = {
         if (match) {
           context.report({
             node,
-            message: match.message || DEFAULT_ERROR_MESSAGE,
+            messageId: match.message ? undefined : 'defaultError',
+            message: match.message, // eslint-disable-line eslint-plugin/prefer-message-ids
             // Uncomment this autofixer to grandfather in existing files.
             // fix(fixer) {
             //   return fixer.insertTextBefore(

--- a/lib/rules/no-test-return-value.js
+++ b/lib/rules/no-test-return-value.js
@@ -4,10 +4,6 @@ const isTestFile = require('../utils/is-test-file');
 const isTestHook = require('../utils/is-test-hook');
 const getParentFunctionNode = require('../utils/get-parent-function-node');
 
-const ERROR_MESSAGE =
-  'Test functions should not return a value. If you want to wait on a promise, use async/await.';
-const SUGGEST_MESSAGE = 'Remove return keyword';
-
 const DEFAULT_TEST_HOOKS = [
   'after',
   'afterEach',
@@ -27,8 +23,6 @@ const DEFAULT_TEST_HOOKS = [
 ];
 
 module.exports = {
-  ERROR_MESSAGE,
-  SUGGEST_MESSAGE,
   DEFAULT_TEST_HOOKS,
   meta: {
     type: 'problem',
@@ -52,6 +46,11 @@ module.exports = {
         additionalProperties: false,
       },
     ],
+    messages: {
+      error:
+        'Test functions should not return a value. If you want to wait on a promise, use async/await.',
+      suggest: 'Remove return keyword',
+    },
     hasSuggestions: true,
   },
   create(context) {
@@ -75,10 +74,10 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: ERROR_MESSAGE,
+            messageId: 'error',
             suggest: [
               {
-                desc: SUGGEST_MESSAGE,
+                messageId: 'suggest',
                 fix(fixer) {
                   return fixer.removeRange([
                     node.range[0],

--- a/lib/rules/no-translation-key-interpolation.js
+++ b/lib/rules/no-translation-key-interpolation.js
@@ -3,14 +3,10 @@
 const isIdentifier = require('../utils/is-identifier');
 const isMemberExpression = require('../utils/is-member-expression');
 
-const ERROR_MESSAGE =
-  'Avoid using string interpolation to construct translation keys. Consider using a `switch` statement instead.';
-
 const DEFAULT_SERVICE_NAME = 'intl';
 const DEFAULT_METHOD_NAME = 't';
 
 module.exports = {
-  ERROR_MESSAGE,
   meta: {
     type: 'suggestion',
     docs: {
@@ -29,6 +25,10 @@ module.exports = {
         additionalProperties: false,
       },
     ],
+    messages: {
+      error:
+        'Avoid using string interpolation to construct translation keys. Consider using a `switch` statement instead.',
+    },
   },
   create(context) {
     return {
@@ -48,7 +48,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: ERROR_MESSAGE,
+            messageId: 'error',
           });
         }
       },

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -52,6 +52,9 @@ module.exports = {
         additionalProperties: false,
       },
     ],
+    messages: {
+      error: 'Use `await` with `{{ calleeName }}` function call.',
+    },
   },
   create(context) {
     return {
@@ -69,7 +72,7 @@ module.exports = {
           // Missing `await`.
           context.report({
             node,
-            message: 'Use `await` with `{{ calleeName }}` function call.',
+            messageId: 'error',
             data: {
               calleeName: node.callee.name,
             },

--- a/lib/rules/use-call-count-test-assert.js
+++ b/lib/rules/use-call-count-test-assert.js
@@ -2,9 +2,6 @@
 
 const isTestFile = require('../utils/is-test-file');
 
-const ERROR_MESSAGE =
-  'Use `assert.equal(...callCount, ...);` to get more helpful test failure messages.';
-
 const ASSERT_PROPERTY_NAMES = ['ok', 'notOk'];
 
 const STUB_PROPERTY_NAMES = [
@@ -16,7 +13,6 @@ const STUB_PROPERTY_NAMES = [
 ];
 
 module.exports = {
-  ERROR_MESSAGE,
   ASSERT_PROPERTY_NAMES,
   STUB_PROPERTY_NAMES,
   meta: {
@@ -29,6 +25,10 @@ module.exports = {
     },
     fixable: 'code',
     schema: [],
+    messages: {
+      error:
+        'Use `assert.equal(...callCount, ...);` to get more helpful test failure messages.',
+    },
   },
   create(context) {
     if (!isTestFile(context.getFilename())) {
@@ -65,7 +65,7 @@ module.exports = {
 
         context.report({
           node,
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           fix(fixer) {
             // Get `calledOnce` (as an example).
             const isAssertNotOkayCalled =

--- a/lib/rules/use-ember-find.js
+++ b/lib/rules/use-ember-find.js
@@ -3,9 +3,6 @@
 const isStringLiteral = require('../utils/is-string-literal');
 const isTestFile = require('../utils/is-test-file');
 
-const ERROR_MESSAGE =
-  "Use Ember's `find` helper instead of `jQuery` for selecting elements in tests.";
-
 module.exports = {
   meta: {
     type: 'problem',
@@ -17,9 +14,11 @@ module.exports = {
     },
     fixable: 'code',
     schema: [],
+    messages: {
+      error:
+        "Use Ember's `find` helper instead of `jQuery` for selecting elements in tests.",
+    },
   },
-
-  ERROR_MESSAGE,
 
   create(context) {
     if (!isTestFile(context.getFilename())) {
@@ -33,7 +32,7 @@ module.exports = {
         if (isJQueryCallWithSelector(node)) {
           context.report({
             node,
-            message: ERROR_MESSAGE,
+            messageId: 'error',
 
             fix(fixer) {
               // The strategy is to replace the `$` or `jQuery` with `find` and

--- a/tests/lib/rules/no-assert-ok-find.js
+++ b/tests/lib/rules/no-assert-ok-find.js
@@ -3,8 +3,6 @@
 const rule = require('../../../lib/rules/no-assert-ok-find');
 const RuleTester = require('eslint').RuleTester;
 
-const { ERROR_MESSAGE, SUGGEST_MESSAGE } = rule;
-
 const TEST_FILE_NAME = 'some-test.js';
 const NON_TEST_FILE_NAME = 'some-file.js';
 
@@ -57,11 +55,11 @@ ruleTester.run('no-assert-ok-find', rule, {
       globals: { find: true },
       errors: [
         {
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           type: 'CallExpression',
           suggestions: [
             {
-              desc: SUGGEST_MESSAGE,
+              messageId: 'changeToAssertEqualFindLength',
               output: "assert.equal(find('.class').length, 1);",
             },
           ],
@@ -75,11 +73,11 @@ ruleTester.run('no-assert-ok-find', rule, {
       globals: { find: true },
       errors: [
         {
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           type: 'CallExpression',
           suggestions: [
             {
-              desc: SUGGEST_MESSAGE,
+              messageId: 'changeToAssertEqualFindLength',
               output: "assert.equal(find('.class').length, 1, 'it exists');",
             },
           ],

--- a/tests/lib/rules/no-handlebar-interpolation.js
+++ b/tests/lib/rules/no-handlebar-interpolation.js
@@ -37,8 +37,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],
@@ -52,8 +51,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       options: [{ filePatterns: [/\.hbs$/] }],
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],
@@ -66,8 +64,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],
@@ -80,8 +77,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],
@@ -94,8 +90,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       options: [{ filePatterns: [/\.hbs$/, /\.js$/] }],
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],
@@ -108,8 +103,7 @@ ruleTester.run('no-handlebar-interpolation', rule, {
       options: [{ filePatterns: [/\.hbs$/, /\.js$/] }],
       errors: [
         {
-          message:
-            'Use of "no-handlebar-interpolation" `{{{` to insert unsafe HTML is not allowed',
+          messageId: 'error',
           type: 'Literal',
         },
       ],

--- a/tests/lib/rules/no-missing-tests.js
+++ b/tests/lib/rules/no-missing-tests.js
@@ -6,8 +6,6 @@ const path = require('path');
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-missing-tests');
 
-const { ERROR_MESSAGE } = rule;
-
 const ruleTester = new RuleTester();
 
 const RULES_TESTS_PATH = __dirname;
@@ -64,7 +62,7 @@ ruleTester.run('no-missing-tests', rule, {
           },
         ],
       ],
-      errors: [{ message: ERROR_MESSAGE, line: 1, column: 1, type: 'Program' }],
+      errors: [{ messageId: 'error', line: 1, column: 1, type: 'Program' }],
     },
     {
       filename: RULE_FILE,
@@ -79,7 +77,7 @@ ruleTester.run('no-missing-tests', rule, {
           },
         ],
       ],
-      errors: [{ message: ERROR_MESSAGE, line: 1, column: 1, type: 'Program' }],
+      errors: [{ messageId: 'error', line: 1, column: 1, type: 'Program' }],
     },
   ],
 });

--- a/tests/lib/rules/no-restricted-files.js
+++ b/tests/lib/rules/no-restricted-files.js
@@ -1,8 +1,6 @@
 const rule = require('../../../lib/rules/no-restricted-files');
 const RuleTester = require('eslint').RuleTester;
 
-const { DEFAULT_ERROR_MESSAGE } = rule;
-
 const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
@@ -29,7 +27,7 @@ ruleTester.run('no-restricted-files', rule, {
       code: 'const x = 123;',
       output: null,
       options: [{ paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS] }],
-      errors: [{ message: DEFAULT_ERROR_MESSAGE, type: 'Program' }],
+      errors: [{ messageId: 'defaultError', type: 'Program' }],
     },
     {
       // With custom error message:

--- a/tests/lib/rules/no-test-return-value.js
+++ b/tests/lib/rules/no-test-return-value.js
@@ -3,7 +3,7 @@
 const rule = require('../../../lib/rules/no-test-return-value');
 const RuleTester = require('eslint').RuleTester;
 
-const { DEFAULT_TEST_HOOKS, ERROR_MESSAGE, SUGGEST_MESSAGE } = rule;
+const { DEFAULT_TEST_HOOKS } = rule;
 
 const TEST_FILE_NAME = 'some-test.js';
 const NON_TEST_FILE_NAME = 'some-file.js';
@@ -57,11 +57,11 @@ ruleTester.run('no-test-return-value', rule, {
       output: null,
       errors: [
         {
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           type: 'ReturnStatement',
           suggestions: [
             {
-              desc: SUGGEST_MESSAGE,
+              messageId: 'suggest',
               output: `${testHook}(function() { 1; })`,
             },
           ],
@@ -78,11 +78,11 @@ ruleTester.run('no-test-return-value', rule, {
       options: [{ testHooks: ['testHook'] }],
       errors: [
         {
-          message: ERROR_MESSAGE,
+          messageId: 'error',
           type: 'ReturnStatement',
           suggestions: [
             {
-              desc: SUGGEST_MESSAGE,
+              messageId: 'suggest',
               output: `
         testHook(function(condition) {
           condition ? 1 : 2;

--- a/tests/lib/rules/no-translation-key-interpolation.js
+++ b/tests/lib/rules/no-translation-key-interpolation.js
@@ -3,8 +3,6 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-translation-key-interpolation');
 
-const { ERROR_MESSAGE } = rule;
-
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2020,
@@ -47,18 +45,18 @@ ruleTester.run('no-translation-key-interpolation', rule, {
     {
       code: 'intl.t(`key.${variable}`);', // eslint-disable-line no-template-curly-in-string
       output: null,
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       // With variable:
       code: 'intl.t(`key.${variable}`, { someVariable: 123 });', // eslint-disable-line no-template-curly-in-string
       output: null,
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       code: 'this.intl.t(`key.${variable}`);', // eslint-disable-line no-template-curly-in-string
       output: null,
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
 
     // Custom service name:
@@ -66,7 +64,7 @@ ruleTester.run('no-translation-key-interpolation', rule, {
       code: 'this.i18n.t(`key.${variable}`);', // eslint-disable-line no-template-curly-in-string
       output: null,
       options: [{ serviceName: 'i18n' }],
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
   ],
 });

--- a/tests/lib/rules/use-call-count-test-assert.js
+++ b/tests/lib/rules/use-call-count-test-assert.js
@@ -3,7 +3,7 @@
 const rule = require('../../../lib/rules/use-call-count-test-assert');
 const RuleTester = require('eslint').RuleTester;
 
-const { ERROR_MESSAGE, ASSERT_PROPERTY_NAMES, STUB_PROPERTY_NAMES } = rule;
+const { ASSERT_PROPERTY_NAMES, STUB_PROPERTY_NAMES } = rule;
 
 const TEST_FILE_NAME = 'some-test.js';
 const NON_TEST_FILE_NAME = 'some-file.js';
@@ -77,7 +77,7 @@ const INVALID_HELPER_USAGES = ASSERT_PROPERTY_NAMES.flatMap(
       const ex1 = {
         code: `assert.${assertPropertyName}(myStub.${stubPropertyName});`,
         output: null,
-        errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+        errors: [{ messageId: 'error', type: 'CallExpression' }],
         filename: TEST_FILE_NAME,
       };
 
@@ -85,7 +85,7 @@ const INVALID_HELPER_USAGES = ASSERT_PROPERTY_NAMES.flatMap(
       const ex2 = {
         code: `assert.${assertPropertyName}(this.prop.myStub.${stubPropertyName});`,
         output: null,
-        errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+        errors: [{ messageId: 'error', type: 'CallExpression' }],
         filename: TEST_FILE_NAME,
       };
 
@@ -93,7 +93,7 @@ const INVALID_HELPER_USAGES = ASSERT_PROPERTY_NAMES.flatMap(
       const ex3 = {
         code: `assert.${assertPropertyName}(myStub.${stubPropertyName}, 'is called the right number of times');`,
         output: null,
-        errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+        errors: [{ messageId: 'error', type: 'CallExpression' }],
         filename: TEST_FILE_NAME,
       };
 

--- a/tests/lib/rules/use-ember-find.js
+++ b/tests/lib/rules/use-ember-find.js
@@ -3,8 +3,6 @@
 const rule = require('../../../lib/rules/use-ember-find');
 const RuleTester = require('eslint').RuleTester;
 
-const { ERROR_MESSAGE } = rule;
-
 const TEST_FILE_NAME = 'some-test.js';
 
 const ruleTester = new RuleTester();
@@ -65,20 +63,20 @@ ruleTester.run('use-ember-find', rule, {
       filename: TEST_FILE_NAME,
       code: "$('.some-selector');",
       output: "find('.some-selector', 'body');",
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       filename: TEST_FILE_NAME,
       code: "($)('.some-selector');",
       output: "(find)('.some-selector', 'body');",
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       filename: TEST_FILE_NAME,
       code: '$(`.some-${selector}`);', // eslint-disable-line no-template-curly-in-string
       output: "find(`.some-${selector}`, 'body');", // eslint-disable-line no-template-curly-in-string
       parserOptions: { ecmaVersion: 2020 },
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
 
     // Using `jQuery`:
@@ -86,20 +84,20 @@ ruleTester.run('use-ember-find', rule, {
       filename: TEST_FILE_NAME,
       code: "jQuery('.some-selector');",
       output: "find('.some-selector', 'body');",
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       filename: TEST_FILE_NAME,
       code: "(jQuery)('.some-selector');",
       output: "(find)('.some-selector', 'body');",
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
     {
       filename: TEST_FILE_NAME,
       code: 'jQuery(`.some-${selector}`);', // eslint-disable-line no-template-curly-in-string
       output: "find(`.some-${selector}`, 'body');", // eslint-disable-line no-template-curly-in-string
       parserOptions: { ecmaVersion: 2020 },
-      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
   ],
 });


### PR DESCRIPTION
More modern.

Enables: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-message-ids.md