### PR TITLE
Remove custom config for `eslint-plugin/consistent-output` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     sourceType: 'script',
   },
   rules: {
-    'eslint-plugin/consistent-output': ['error', 'always'],
     'eslint-plugin/require-meta-docs-url': [
       'error',
       {


### PR DESCRIPTION
Just use the default config for this rule: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/consistent-output.md

It's enabled as `recommended` in eslint-plugin-eslint-plugin v4.