### PR TITLE
Drop support below ESLint 7.32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,3 @@ jobs:
     - run: yarn lint
 
     - run: yarn test
-
-    - run: yarn add --dev eslint@6 && yarn test && yarn lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 
 ## Requirements
 
-* [ESLint](https://eslint.org/) `>= 6`
+* [ESLint](https://eslint.org/) `>= 7.32.0`
 * [Node.js](https://nodejs.org/) `12.* || 14.* || >= 16.*`
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sort-package-json": "^1.50.0"
   },
   "peerDependencies": {
-    "eslint": ">= 6"
+    "eslint": ">= 7.32.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16.*"


### PR DESCRIPTION
This is needed because eslint-plugin-unicorn only supports 7.32 and above now: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/5f3bad533843ca939e46bbec05ea358c32d28fa7/package.json#L82

7.32 is the final version in the v7 series: https://eslint.org/blog/2021/07/eslint-v7.32.0-released