### PR TITLE
Add jsdoc `type` annotation to rules

### DIFF
--- a/lib/rules/no-assert-ok-find.js
+++ b/lib/rules/no-assert-ok-find.js
@@ -4,6 +4,9 @@ const isMemberExpression = require('../utils/is-member-expression');
 const isTestFile = require('../utils/is-test-file');
 const { ReferenceTracker } = require('eslint-utils');
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-handlebar-interpolation.js
+++ b/lib/rules/no-handlebar-interpolation.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-missing-tests.js
+++ b/lib/rules/no-missing-tests.js
@@ -3,6 +3,9 @@
 const { existsSync } = require('fs');
 const path = require('path');
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-test-return-value.js
+++ b/lib/rules/no-test-return-value.js
@@ -22,6 +22,9 @@ const DEFAULT_TEST_HOOKS = [
   'todo',
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   DEFAULT_TEST_HOOKS,
   meta: {

--- a/lib/rules/no-translation-key-interpolation.js
+++ b/lib/rules/no-translation-key-interpolation.js
@@ -6,6 +6,9 @@ const isMemberExpression = require('../utils/is-member-expression');
 const DEFAULT_SERVICE_NAME = 'intl';
 const DEFAULT_METHOD_NAME = 't';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -29,6 +29,9 @@ function isAwaitCall(node) {
   return false;
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/use-call-count-test-assert.js
+++ b/lib/rules/use-call-count-test-assert.js
@@ -12,6 +12,9 @@ const STUB_PROPERTY_NAMES = [
   'called',
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ASSERT_PROPERTY_NAMES,
   STUB_PROPERTY_NAMES,

--- a/lib/rules/use-ember-find.js
+++ b/lib/rules/use-ember-find.js
@@ -3,6 +3,9 @@
 const isStringLiteral = require('../utils/is-string-literal');
 const isTestFile = require('../utils/is-test-file');
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',


### PR DESCRIPTION
Supported by VSCode/Webstorm/other code editors. Uses TypeScript declaration to give JavaScript hints so code editors can provide information/autocomplete about various rule fields.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113