### PR TITLE
Mention related rule `qunit-dom/no-ok-find` in `square/no-assert-ok-find` rule doc

### DIFF
--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -48,3 +48,4 @@ test('the element exists', function (assert) {
 
 * See the [documentation](https://guides.emberjs.com/v2.14.0/testing/acceptance/) for Ember's `find` acceptance test helper
 * See the [documentation](https://github.com/simplabs/qunit-dom) for the `qunit-dom` package
+* Related rule: [qunit-dom/no-ok-find](https://github.com/simplabs/eslint-plugin-qunit-dom/blob/main/rules/no-ok-find.md)


### PR DESCRIPTION
We could eventually delete this rule from eslint-plugin-square once all its functionality is ported to the similar rule in eslint-plugin-qunit-dom.

CC: @Turbo87

https://github.com/square/eslint-plugin-square/blob/master/docs/rules/no-assert-ok-find.md
https://github.com/simplabs/eslint-plugin-qunit-dom/blob/main/rules/no-ok-find.md