### PR TITLE
Automatically provide `square` plugin so consumers don't have to specify it

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: [
-    './lib/config/base.js',
     'plugin:eslint-plugin/all',
     'plugin:node/recommended',
+    'plugin:square/base',
   ],
   plugins: ['eslint-plugin'],
   parserOptions: {

--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -8,7 +8,7 @@
     "prefer-alphabetical-optionalDependencies": "error",
     "prefer-alphabetical-scripts": "error",
     "prefer-caret-version-dependencies": "error",
-    "prefer-caret-version-devDependencies": "error",
+    "prefer-caret-version-devDependencies": ["error", { "exceptions": ["eslint-plugin-square"] }],
     "prefer-scripts": ["error", ["lint", "test"]]
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Edit your `.eslintrc.js` configuration file to extend one of the available confi
 
 ```js
 module.exports = {
-  plugins: ['square'],
   extends: ['plugin:square/base'], // Or other configuration.
 };
 ```

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -20,6 +20,7 @@ module.exports = {
     'filenames',
     'import',
     'prettier',
+    'square',
     'unicorn',
   ],
   rules: {

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -10,7 +10,7 @@ module.exports = {
     'plugin:ember/recommended',
     'plugin:qunit/recommended',
   ],
-  plugins: ['ember', 'qunit', 'square'],
+  plugins: ['ember', 'qunit'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',

--- a/lib/config/strict.js
+++ b/lib/config/strict.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   extends: [require.resolve('./base')],
-  plugins: ['square'],
   rules: {
     // Optional eslint rules:
     'no-console': 'error',

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-eslint-plugin": "^4.0.1",
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-square": "file:./",
     "markdownlint-cli": "^0.30.0",
     "mocha": "^9.1.3",
     "npm-package-json-lint": "^5.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,6 +1793,25 @@ eslint-plugin-react@^7.26.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
 
+"eslint-plugin-square@file:.":
+  version "21.0.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^5.1.0"
+    eslint-config-prettier "^8.3.0"
+    eslint-plugin-ember "^10.5.7"
+    eslint-plugin-es "^4.1.0"
+    eslint-plugin-eslint-comments "^3.2.0"
+    eslint-plugin-filenames "^1.3.2"
+    eslint-plugin-import "^2.25.2"
+    eslint-plugin-prettier "^4.0.0"
+    eslint-plugin-qunit "^7.0.0"
+    eslint-plugin-react "^7.26.1"
+    eslint-plugin-unicorn "^37.0.1"
+    eslint-utils "^3.0.0"
+    espree "^9.0.0"
+    prettier "^2.4.1"
+    requireindex "^1.2.0"
+
 eslint-plugin-unicorn@^37.0.1:
   version "37.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz#a2292dc302ffc0be1791e6ebbb4ae93242833f11"


### PR DESCRIPTION
Before this change, it was provided in some of our configs but not all of them.

Now, consumers will never have to specify this, regardless of which of our configs they use:

```
plugins: ['square'],
```

Relies on this solution for internal linting of this plugin: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/231