### PR TITLE
Don't require `await` in return statements in `require-await-function` rule

### DIFF
--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -8,11 +8,13 @@ Some functions are asynchronous and you may want to wait for their code to finis
 
 ## Rule Details
 
-This lint rule requires that specified functions be called with the `async` keyword. The benefits of this include:
+This lint rule requires that specified functions be called with the `await` keyword. The benefits of this include:
 
 * Ensure code runs in the right (deterministic) order
 * Promote cleaner code by reducing unwieldy promise chain usage
 * Enforce a consistent way of calling/chaining asynchronous functions
+
+Note: this rule does not require using `await` in return statements or when nested inside other function calls.
 
 ## Examples
 

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -9,7 +9,7 @@ const isMemberExpression = require('../utils/is-member-expression');
  * @param {ASTNode} node - the node to check.
  * @returns {boolean} `true` if the node is part of a call with the `await` keyword.
  */
-function isAwaitOrReturnCall(node) {
+function isAwaitOrReturnCall(node, isPromiseChain = false) {
   if (!node.parent) {
     // Can't be part of an AwaitExpression if it has no parent.
     return false;
@@ -25,9 +25,17 @@ function isAwaitOrReturnCall(node) {
     return true;
   }
 
-  if (parent.type === 'CallExpression' || isMemberExpression(parent)) {
+  if (parent.type === 'CallExpression') {
+    if (isPromiseChain) {
+      return isAwaitOrReturnCall(parent, isPromiseChain);
+    } else {
+      return true;
+    }
+  }
+
+  if (isMemberExpression(parent)) {
     // Check to see if the AwaitExpression is still another level above.
-    return isAwaitOrReturnCall(parent);
+    return isAwaitOrReturnCall(parent, true);
   }
 
   return false;

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -10,11 +10,6 @@ const isMemberExpression = require('../utils/is-member-expression');
  * @returns {boolean} `true` if the node is part of a call with the `await` keyword.
  */
 function isAwaitCall(node) {
-  if (!node.parent) {
-    // Can't be part of an AwaitExpression if it has no parent.
-    return false;
-  }
-
   const parent = node.parent;
 
   if (parent.type === 'AwaitExpression') {
@@ -36,11 +31,6 @@ function isAwaitCall(node) {
  * @returns {boolean} `true` if the node is part of a returned call
  */
 function isReturnCall(node) {
-  if (!node.parent) {
-    // Can't be part of a ReturnStatement if it has no parent.
-    return false;
-  }
-
   const parent = node.parent;
 
   if (
@@ -64,11 +54,6 @@ function isReturnCall(node) {
  * @returns {boolean} `true` if the node is nested within another function
  */
 function isNestedCall(node, isPromiseChain = false) {
-  if (!node.parent) {
-    // Can't be part of an AwaitExpression if it has no parent.
-    return false;
-  }
-
   const parent = node.parent;
 
   if (parent.type === 'CallExpression') {

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -17,7 +17,11 @@ function isAwaitOrReturnCall(node) {
 
   const parent = node.parent;
 
-  if (parent.type === 'AwaitExpression' || parent.type === 'ReturnStatement') {
+  if (
+    parent.type === 'AwaitExpression' ||
+    parent.type === 'ReturnStatement' ||
+    parent.type === 'ArrowFunctionExpression'
+  ) {
     return true;
   }
 

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -4,12 +4,12 @@ const isIdentifier = require('../utils/is-identifier');
 const isMemberExpression = require('../utils/is-member-expression');
 
 /**
- * Checks if the given node is part of a call with the `await` keyword or a direct `return`.
+ * Checks if the given node is part of a call with the `await` keyword.
  *
  * @param {ASTNode} node - the node to check.
  * @returns {boolean} `true` if the node is part of a call with the `await` keyword.
  */
-function isAwaitOrReturnCall(node, isPromiseChain = false) {
+function isAwaitCall(node) {
   if (!node.parent) {
     // Can't be part of an AwaitExpression if it has no parent.
     return false;
@@ -17,25 +17,70 @@ function isAwaitOrReturnCall(node, isPromiseChain = false) {
 
   const parent = node.parent;
 
+  if (parent.type === 'AwaitExpression') {
+    return true;
+  }
+
+  if (parent.type === 'CallExpression' || isMemberExpression(parent)) {
+    // Check to see if the AwaitExpression is still another level above.
+    return isAwaitCall(parent);
+  }
+
+  return false;
+}
+
+/**
+ * Checks if the given node is part of a call with the `return` keyword or direct arrow return.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is part of a returned call
+ */
+function isReturnCall(node) {
+  if (!node.parent) {
+    // Can't be part of a ReturnStatement if it has no parent.
+    return false;
+  }
+
+  const parent = node.parent;
+
   if (
-    parent.type === 'AwaitExpression' ||
     parent.type === 'ReturnStatement' ||
     parent.type === 'ArrowFunctionExpression'
   ) {
     return true;
   }
 
+  if (parent.type === 'CallExpression' || isMemberExpression(parent)) {
+    return isReturnCall(parent);
+  }
+
+  return false;
+}
+
+/**
+ * Checks if the given node is a nested call
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is nested within another function
+ */
+function isNestedCall(node, isPromiseChain = false) {
+  if (!node.parent) {
+    // Can't be part of an AwaitExpression if it has no parent.
+    return false;
+  }
+
+  const parent = node.parent;
+
   if (parent.type === 'CallExpression') {
     if (isPromiseChain) {
-      return isAwaitOrReturnCall(parent, isPromiseChain);
+      return isNestedCall(parent, false);
     } else {
       return true;
     }
   }
 
   if (isMemberExpression(parent)) {
-    // Check to see if the AwaitExpression is still another level above.
-    return isAwaitOrReturnCall(parent, true);
+    return isNestedCall(parent, true);
   }
 
   return false;
@@ -81,7 +126,7 @@ module.exports = {
           return;
         }
 
-        if (!isAwaitOrReturnCall(node)) {
+        if (!isAwaitCall(node) && !isReturnCall(node) && !isNestedCall(node)) {
           // Missing `await`.
           context.report({
             node,

--- a/lib/rules/require-await-function.js
+++ b/lib/rules/require-await-function.js
@@ -4,12 +4,12 @@ const isIdentifier = require('../utils/is-identifier');
 const isMemberExpression = require('../utils/is-member-expression');
 
 /**
- * Checks if the given node is part of a call with the `await` keyword.
+ * Checks if the given node is part of a call with the `await` keyword or a direct `return`.
  *
  * @param {ASTNode} node - the node to check.
  * @returns {boolean} `true` if the node is part of a call with the `await` keyword.
  */
-function isAwaitCall(node) {
+function isAwaitOrReturnCall(node) {
   if (!node.parent) {
     // Can't be part of an AwaitExpression if it has no parent.
     return false;
@@ -17,13 +17,13 @@ function isAwaitCall(node) {
 
   const parent = node.parent;
 
-  if (parent.type === 'AwaitExpression') {
+  if (parent.type === 'AwaitExpression' || parent.type === 'ReturnStatement') {
     return true;
   }
 
   if (parent.type === 'CallExpression' || isMemberExpression(parent)) {
     // Check to see if the AwaitExpression is still another level above.
-    return isAwaitCall(parent);
+    return isAwaitOrReturnCall(parent);
   }
 
   return false;
@@ -69,7 +69,7 @@ module.exports = {
           return;
         }
 
-        if (!isAwaitCall(node)) {
+        if (!isAwaitOrReturnCall(node)) {
           // Missing `await`.
           context.report({
             node,

--- a/tests/lib/rules/require-await-function.js
+++ b/tests/lib/rules/require-await-function.js
@@ -31,6 +31,11 @@ const VALID_USAGES = [
     options: [{ functions: ['asyncFunc'] }],
   },
   {
+    // Part of a nested function call, foo() might want to consume a promise directly
+    code: 'function test() { foo(asyncFunc()); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
     // Returning the result of a nested function call
     code: 'function test() { return foo(asyncFunc()); }',
     options: [{ functions: ['asyncFunc'] }],
@@ -58,18 +63,6 @@ const INVALID_USAGES = [
     code: 'async function test() { asyncFunc(); }',
     options: [{ functions: ['asyncFunc'] }],
     output: 'async function test() { await asyncFunc(); }',
-    errors: [
-      {
-        message: 'Use `await` with `asyncFunc` function call.',
-        type: 'CallExpression',
-      },
-    ],
-  },
-  {
-    // Missing `await` and part of nested function call.
-    code: 'async function test() { foo(asyncFunc()); }',
-    options: [{ functions: ['asyncFunc'] }],
-    output: 'async function test() { foo(await asyncFunc()); }',
     errors: [
       {
         message: 'Use `await` with `asyncFunc` function call.',

--- a/tests/lib/rules/require-await-function.js
+++ b/tests/lib/rules/require-await-function.js
@@ -31,6 +31,16 @@ const VALID_USAGES = [
     options: [{ functions: ['asyncFunc'] }],
   },
   {
+    // Returning the result of a nested function call
+    code: 'function test() { return foo(asyncFunc()); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
+    // Returning the result of a nested arrow function call
+    code: 'const test = () => foo(asyncFunc());',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
     // Not one of the specified functions.
     code: 'otherFunc();',
     options: [{ functions: ['asyncFunc'] }],
@@ -48,6 +58,18 @@ const INVALID_USAGES = [
     code: 'async function test() { asyncFunc(); }',
     options: [{ functions: ['asyncFunc'] }],
     output: 'async function test() { await asyncFunc(); }',
+    errors: [
+      {
+        message: 'Use `await` with `asyncFunc` function call.',
+        type: 'CallExpression',
+      },
+    ],
+  },
+  {
+    // Missing `await` and part of nested function call.
+    code: 'async function test() { foo(asyncFunc()); }',
+    options: [{ functions: ['asyncFunc'] }],
+    output: 'async function test() { foo(await asyncFunc()); }',
     errors: [
       {
         message: 'Use `await` with `asyncFunc` function call.',

--- a/tests/lib/rules/require-await-function.js
+++ b/tests/lib/rules/require-await-function.js
@@ -26,6 +26,11 @@ const VALID_USAGES = [
     options: [{ functions: ['asyncFunc'] }],
   },
   {
+    // Arrow function directly returning the result
+    code: 'const myFunction = () => asyncFunc();',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
     // Not one of the specified functions.
     code: 'otherFunc();',
     options: [{ functions: ['asyncFunc'] }],

--- a/tests/lib/rules/require-await-function.js
+++ b/tests/lib/rules/require-await-function.js
@@ -21,6 +21,11 @@ const VALID_USAGES = [
     options: [{ functions: ['asyncFunc'] }],
   },
   {
+    // Returning the result of the async function
+    code: 'function myFunction() { return asyncFunc(); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
     // Not one of the specified functions.
     code: 'otherFunc();',
     options: [{ functions: ['asyncFunc'] }],


### PR DESCRIPTION
This change allows for direct `return requiredAsyncFunc()`

Otherwise it conflicts with "no-return-await" rule of disallowing `return await requiredAsyncFunc();`