### PR TITLE
Add more async Ember test helpers

### DIFF
--- a/lib/utils/async-ember-test-helpers.js
+++ b/lib/utils/async-ember-test-helpers.js
@@ -1,17 +1,31 @@
 'use strict';
 
+// https://github.com/emberjs/ember-test-helpers/blob/master/API.md
 const ASYNC_EMBER_TEST_HELPERS = [
   'blur',
+  'clearRender',
   'click',
   'doubleClick',
   'fillIn',
   'focus',
+  'pauseTest',
+  'render',
+  'resumeTest',
+  'scrollTo',
+  'select',
+  'settled',
+  'setupApplicationContext',
+  'setupContext',
+  'setupRenderingContext',
   'tap',
+  'teardownContext',
   'triggerEvent',
   'triggerKeyEvent',
   'typeIn',
   'visit',
   'wait',
+  'waitFor',
+  'waitUntil',
 ];
 
 module.exports = ASYNC_EMBER_TEST_HELPERS;


### PR DESCRIPTION
In the `ember` config, we store a list of the Ember async test helpers that should be called with `await` as enforced by the [square/require-await-function](https://github.com/square/eslint-plugin-square/blob/master/docs/rules/require-await-function.md) rule.

This PR improves the completeness of this list.

https://github.com/emberjs/ember-test-helpers/blob/master/API.md