### PR TITLE
Tell dependabot to increase versions in package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 15
+    versioning-strategy: 'increase' # Update versions in both package.json and lockfile
     schedule:
       interval: 'weekly'
 


### PR DESCRIPTION
For our `dependencies` in package.json, we need to update their versions in both package.json and the lockfile, not just the lockfile, for the update to have an effect on consumers. If we only update a version in the lockfile, it will affect us, but not consumers of this plugin.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy