### PR TITLE
Drop support for old minor versions of Node 12 and 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 ## Requirements
 
 * [ESLint](https://eslint.org/) `>= 8.8.0`
-* [Node.js](https://nodejs.org/) `12.* || 14.* || >= 16.*`
+* [Node.js](https://nodejs.org/) `^12.22.0 || ^14.17.0 || >=16.0.0`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint": ">= 8.8.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16.*"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This matches ESLint 8, which we now require:
* https://github.com/square/eslint-plugin-square/pull/586