### PR TITLE
Expose `ASYNC_EMBER_TEST_HELPERS` in public Node API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,5 +7,6 @@ module.exports = {
   configs: requireIndex(`${__dirname}/config`),
   utils: {
     filenames: require('./utils/filenames'),
+    ASYNC_EMBER_TEST_HELPERS: require('./utils/async-ember-test-helpers'),
   },
 };


### PR DESCRIPTION
Needed since this array can no longer be accessed directly:

* #587

Before:

```js
const ASYNC_EMBER_TEST_HELPERS = require('eslint-plugin-square/lib/utils/async-ember-test-helpers');
```

After:

```js
const { utils } = require('eslint-plugin-square');

console.log(utils.ASYNC_EMBER_TEST_HELPERS);
```