### PR TITLE
Add `enforceStringLiteralKeys` option to `no-translation-key-interpolation` rule

### DIFF
--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -40,6 +40,7 @@ function getStatusString(status) {
 This rule takes an optional object containing:
 
 * `string` -- `serviceName` -- optional override for service name to look for (default is `intl`)
+* `boolean` -- `enforceStringLiteralKeys` -- optional override to restrict translation keys to only string literals (default is `false`)
 
 ## References
 

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -40,7 +40,7 @@ function getStatusString(status) {
 This rule takes an optional object containing:
 
 * `string` -- `serviceName` -- optional override for service name to look for (default is `intl`)
-* `boolean` -- `enforceStringLiteralKeys` -- optional override to restrict translation keys to only string literals (default is `false`)
+* `boolean` -- `enforceStringLiteralKeys` -- optional override to restrict translation keys to only string literals (when disabled, function calls and variables are allowed) (default is `false`)
 
 ## References
 

--- a/lib/rules/no-translation-key-interpolation.js
+++ b/lib/rules/no-translation-key-interpolation.js
@@ -23,6 +23,10 @@ module.exports = {
           serviceName: {
             type: 'string',
           },
+          enforceStringLiteralKeys: {
+            type: 'boolean',
+            default: false,
+          },
         },
         additionalProperties: false,
       },
@@ -38,6 +42,10 @@ module.exports = {
         context.options.length > 0 &&
         context.options[0].serviceName) ||
       DEFAULT_SERVICE_NAME;
+    const enforceStringLiteralKeys =
+      context.options &&
+      context.options.length > 0 &&
+      context.options[0].enforceStringLiteralKeys;
     let importedTranslationMethodName;
 
     return {
@@ -54,13 +62,18 @@ module.exports = {
           (isT(node, importedTranslationMethodName) ||
             isIntlT(node, serviceName) ||
             isThisIntlT(node, serviceName)) &&
-          (node.arguments.length === 1 || node.arguments.length === 2) &&
-          node.arguments[0].type === 'TemplateLiteral'
+          (node.arguments.length === 1 || node.arguments.length === 2)
         ) {
-          context.report({
-            node,
-            messageId: 'error',
-          });
+          if (
+            (enforceStringLiteralKeys &&
+              node.arguments[0].type !== 'Literal') ||
+            node.arguments[0].type === 'TemplateLiteral'
+          ) {
+            context.report({
+              node,
+              messageId: 'error',
+            });
+          }
         }
       },
     };

--- a/tests/lib/rules/no-translation-key-interpolation.js
+++ b/tests/lib/rules/no-translation-key-interpolation.js
@@ -59,6 +59,12 @@ ruleTester.run('no-translation-key-interpolation', rule, {
     't(SOME_VARIABLE);',
     't(constructKey());',
     't(`key.${variable}`);', // eslint-disable-line no-template-curly-in-string
+
+    // Enforce string literal keys:
+    {
+      code: "intl.t('some.key');",
+      options: [{ enforceStringLiteralKeys: true }],
+    },
   ],
   invalid: [
     {
@@ -110,6 +116,20 @@ ruleTester.run('no-translation-key-interpolation', rule, {
         foo(\`key.\${variable}\`);
       `,
       output: null,
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
+    },
+
+    // Enforce string literal keys:
+    {
+      code: 'intl.t(SOME_VARIABLE);',
+      output: null,
+      options: [{ enforceStringLiteralKeys: true }],
+      errors: [{ messageId: 'error', type: 'CallExpression' }],
+    },
+    {
+      code: 'intl.t(constructKey());',
+      output: null,
+      options: [{ enforceStringLiteralKeys: true }],
       errors: [{ messageId: 'error', type: 'CallExpression' }],
     },
   ],


### PR DESCRIPTION
## Description

Allows users to enforce stricter rules on translation keys by only allowing string literals as keys. Previously, rule would allow keys that are functions or variables.

## Testing
`yarn test`  
`yarn eslint .`