### PR TITLE
Drop support below ESLint 8.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 
 ## Requirements
 
-* [ESLint](https://eslint.org/) `>= 8.8.0`
+* [ESLint](https://eslint.org/) `>= 8.18.0`
 * [Node.js](https://nodejs.org/) `^12.22.0 || ^14.17.0 || >=16.0.0`
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sort-package-json": "^1.57.0"
   },
   "peerDependencies": {
-    "eslint": ">= 8.8.0"
+    "eslint": ">= 8.18.0"
   },
   "engines": {
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0"


### PR DESCRIPTION
Necessary to upgrade to the latest version of eslint-plugin-unicorn which added this requirement:

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/20e959ffadeca007697534f1ad58c45d29cfdb04/package.json#L93