### PR TITLE
Drop support for Node 12 and Node 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 ## Requirements
 
 * [ESLint](https://eslint.org/) `>= 8.8.0`
-* [Node.js](https://nodejs.org/) `^12.22.0 || ^14.17.0 || >=16.0.0`
+* [Node.js](https://nodejs.org/) `^14.18.0 || ^16.0.0 || >= 18.0.0`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": ">= 8.8.0"
   },
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    "node": "^14.18.0 || ^16.0.0 || >= 18.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Drop Node 12 support (end-of-life 2022-04-30).
Drop Node 17 support (end-of-life 2022-06-01).

Require Node 14.18 minimum so that we can adopt `node:` protocol imports like eslint-plugin-unicorn:

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/20e959ffadeca007697534f1ad58c45d29cfdb04/package.json#L14