### PR TITLE
Enable `unicorn/prefer-node-protocol` rule internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,8 @@ module.exports = {
           'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/{{name}}.md',
       },
     ],
+
+    'unicorn/prefer-node-protocol': 'error', // TODO: Move this to `base` config once we drop support for Node 14 entirely.
   },
   overrides: [
     {

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -146,7 +146,7 @@ module.exports = {
     'unicorn/prefer-dom-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
     'unicorn/prefer-dom-node-text-content': 'off', // The autofixer can be unsafe.
     'unicorn/prefer-module': 'off', // Not ready for this yet.
-    'unicorn/prefer-node-protocol': 'off', // Big change, enable later.
+    'unicorn/prefer-node-protocol': 'off', // TODO: Enable once we drop support for Node 14 entirely.
     'unicorn/prefer-prototype-methods': 'off', // Too noisy for now.
     'unicorn/prefer-query-selector': 'off', // The autofixer can be unsafe.
     'unicorn/prefer-switch': 'off', // Too aggressive for now.

--- a/lib/rules/no-missing-tests.js
+++ b/lib/rules/no-missing-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { existsSync } = require('fs');
-const path = require('path');
+const { existsSync } = require('node:fs');
+const path = require('node:path');
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {

--- a/lib/utils/import.js
+++ b/lib/utils/import.js
@@ -5,7 +5,7 @@
   https://github.com/ember-cli/eslint-plugin-ember/blob/master/lib/utils/import.js
  */
 
-const assert = require('assert');
+const assert = require('node:assert');
 const isIdentifier = require('./is-identifier');
 const isMemberExpression = require('./is-member-expression');
 

--- a/tests/config-setup.js
+++ b/tests/config-setup.js
@@ -1,9 +1,9 @@
 'use strict';
 /* eslint-env node */
 
-const { readdirSync, readFileSync } = require('fs');
-const path = require('path');
-const assert = require('assert');
+const { readdirSync, readFileSync } = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
 const configs = require('../lib').configs;
 
 const CONFIG_NAMES = Object.keys(configs);

--- a/tests/lib/rules/no-missing-tests.js
+++ b/tests/lib/rules/no-missing-tests.js
@@ -2,7 +2,7 @@
 
 /* eslint-env node */
 
-const path = require('path');
+const path = require('node:path');
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-missing-tests');
 

--- a/tests/lib/utils/filenames.js
+++ b/tests/lib/utils/filenames.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const filenames = require('../../../lib/utils/filenames');
-const assert = require('assert');
+const assert = require('node:assert');
 
 describe('filenames', () => {
   // filenames/match-regex ignores file extension so these tests also do

--- a/tests/lib/utils/imports.js
+++ b/tests/lib/utils/imports.js
@@ -3,7 +3,7 @@ const {
 } = require('../../helpers/babel-eslint-parser');
 const { FauxContext } = require('../../helpers/faux-context');
 const importUtils = require('../../../lib/utils/import');
-const assert = require('assert');
+const assert = require('node:assert');
 
 function parse(code) {
   return babelESLintParse(code).body[0].expression;

--- a/tests/lib/utils/is-literal.js
+++ b/tests/lib/utils/is-literal.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const parse = require('espree').parse;
 const isLiteral = require('../../../lib/utils/is-literal');
 

--- a/tests/lib/utils/is-test-file.js
+++ b/tests/lib/utils/is-test-file.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const isTestFile = require('../../../lib/utils/is-test-file');
-const assert = require('assert');
+const assert = require('node:assert');
 
 describe('isTestFile', () => {
   it('detects test files', () => {

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -1,9 +1,9 @@
 'use strict';
 /* eslint-env node */
 
-const { readdirSync, readFileSync } = require('fs');
-const path = require('path');
-const assert = require('assert');
+const { readdirSync, readFileSync } = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
 const rules = require('../lib').rules;
 const configEmber = require('../lib/config/ember');
 


### PR DESCRIPTION
Not enabling in our public `base` config yet since some libraries using eslint-plugin-square may still want to support earlier versions of Node 14 where this feature is not available yet, so we won't enforce this on others until we drop support for Node 14 entirely in 2023.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md