### PR TITLE
Move from deprecated `release-it-lerna-changelog` to `@release-it-plugins/lerna-changelog`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,4 +8,4 @@
 
 4. `export EDITOR="vim"` to choose an editor for editing the changelog
 
-5. `yarn release` (uses [release-it-lerna-changelog](https://github.com/rwjblue/release-it-lerna-changelog) to handle versioning, the changelog, publishing to GitHub and NPM, etc)
+5. `yarn release` (uses [@release-it-plugins/lerna-changelog](https://github.com/release-it-plugins/lerna-changelog) to handle versioning, the changelog, publishing to GitHub and NPM, etc)

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/eslint-parser": "^7.18.9",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.18.9",
+    "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@square/prettier-config": "^2.0.0",
     "eslint": "^8.20.0",
     "eslint-plugin-eslint-plugin": "^5.0.1",
@@ -73,7 +74,6 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "release-it": "^15.2.0",
-    "release-it-lerna-changelog": "^5.0.0",
     "sort-package-json": "^1.57.0"
   },
   "peerDependencies": {
@@ -87,7 +87,7 @@
   },
   "release-it": {
     "plugins": {
-      "release-it-lerna-changelog": {
+      "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md",
         "launchEditor": true
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -638,6 +638,19 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@release-it-plugins/lerna-changelog@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@release-it-plugins/lerna-changelog/-/lerna-changelog-5.0.0.tgz#cbbbc47fd40ef212f2d7c0e24867d3fcea4cd232"
+  integrity sha512-nMhAUptKSfIsiY0c//HuBcd2VT7D/IoxAQNwRgPx+jf3FM7HA5KD4KSl3oLoz4uA4GjvypWQP4ODX8UbWjmUZA==
+  dependencies:
+    execa "^5.1.1"
+    lerna-changelog "^2.2.0"
+    lodash.template "^4.5.0"
+    mdast-util-from-markdown "^1.2.0"
+    tmp "^0.2.1"
+    validate-peer-dependencies "^2.0.0"
+    which "^2.0.2"
+
 "@sindresorhus/is@^5.2.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
@@ -5099,19 +5112,6 @@ registry-url@^6.0.0:
   integrity sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==
   dependencies:
     rc "1.2.8"
-
-release-it-lerna-changelog@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/release-it-lerna-changelog/-/release-it-lerna-changelog-5.0.0.tgz#2df62efc4c7435959201e7d4b50e72db4c111d0e"
-  integrity sha512-s/rHzwAwp878bivWKsJKNya9SRVKYZjgpyyGzg5ddBKZY5u5lhTWhxHtld7mHTRg4azIN7YypPH3rGaOfVmNVw==
-  dependencies:
-    execa "^5.1.1"
-    lerna-changelog "^2.2.0"
-    lodash.template "^4.5.0"
-    mdast-util-from-markdown "^1.2.0"
-    tmp "^0.2.1"
-    validate-peer-dependencies "^2.0.0"
-    which "^2.0.2"
 
 release-it@^15.2.0:
   version "15.2.0"


### PR DESCRIPTION
> This package has been renamed to @release-it-plugins/lerna-changelog

https://github.com/release-it-plugins/lerna-changelog