### PR TITLE
Handle `.d.ts` files correctly for `filenames/match-exported` rule

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -150,11 +150,13 @@ module.exports = {
     'unicorn/prefer-ternary': 'off', // Too many violations.
     'unicorn/prevent-abbreviations': 'off', // Probably not a good fit for us as we use many abbreviations.
   },
-  overrides: {
-    files: ['*.ts'],
-    rules: {
-      // Last parameter allows for exporting from a .d.ts file
-      'filenames/match-exported': ['error', 'kebab', '\\.d$'],
-    }
-  },
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        // Last parameter allows for exporting from a .d.ts file
+        'filenames/match-exported': ['error', 'kebab', '\\.d$'],
+      },
+    },
+  ],
 };

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -152,6 +152,7 @@ module.exports = {
   },
   overrides: [
     {
+      // Tweaks for TypeScript files that we can apply for users even if they don't happen to use our `typescript` config.
       files: ['*.ts'],
       rules: {
         // Last parameter allows for exporting from a .d.ts file

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -152,7 +152,6 @@ module.exports = {
   },
   overrides: {
     files: ['*.ts'],
-    parser: '@typescript-eslint/parser',
     rules: {
       // Last parameter allows for exporting from a .d.ts file
       'filenames/match-exported': ['error', 'kebab', '\\.d$'],

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -150,4 +150,12 @@ module.exports = {
     'unicorn/prefer-ternary': 'off', // Too many violations.
     'unicorn/prevent-abbreviations': 'off', // Probably not a good fit for us as we use many abbreviations.
   },
+  overrides: {
+    files: ['*.ts'],
+    parser: '@typescript-eslint/parser',
+    rules: {
+      // Last parameter allows for exporting from a .d.ts file
+      'filenames/match-exported': ['error', 'kebab', '\\.d$'],
+    }
+  },
 };

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -21,6 +21,7 @@ module.exports = {
           { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
+        'filenames/match-exported': ['error', 'kebab', '\\.d$'],
       },
     },
   ],

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -21,8 +21,6 @@ module.exports = {
           { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
-        // Last parameter allows for exporting from a .d.ts file
-        'filenames/match-exported': ['error', 'kebab', '\\.d$'],
       },
     },
   ],

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -21,6 +21,7 @@ module.exports = {
           { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
+        // Last parameter allows for exporting from a .d.ts file
         'filenames/match-exported': ['error', 'kebab', '\\.d$'],
       },
     },


### PR DESCRIPTION
This would allow the file `model.d.ts` to export something named `Model`.