### PR TITLE
Automatically use `import/typescript` config in `base` config for TypeScript files

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -154,6 +154,7 @@ module.exports = {
     {
       // Tweaks for TypeScript files that we can apply for users even if they don't happen to use our `typescript` config.
       files: ['*.ts'],
+      extends: ['plugin:import/typescript'],
       rules: {
         // Last parameter allows for exporting from a .d.ts file
         'filenames/match-exported': ['error', 'kebab', '\\.d$'],

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -1,6 +1,8 @@
 'use strict';
 
 // This configuration is intended for use in TypeScript projects.
+// Any TypeScript config we can automatically apply for TypeScript files should be done in the `base` config override instead.
+// @typescript-eslint related config must stay in this separate config as moving it to `base` would require a package.json dependency on typescript.
 
 module.exports = {
   extends: [require.resolve('./base')],
@@ -9,10 +11,7 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts'],
-      extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:import/typescript',
-      ],
+      extends: ['plugin:@typescript-eslint/recommended'],
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762
         'no-useless-constructor': 'off',


### PR DESCRIPTION
Not all users use our `typescript` config but they still might have TypeScript files. This part of the `typescript` config we can automatically apply in the `base` config for TypeScript files only.

https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js

Note that we can't move the `@typescript-eslint/recommended` parts of the `typescript` config to `base` because we don't want to add a package.json dependency on `typescript` (tried in https://github.com/square/eslint-plugin-square/pull/250 https://github.com/square/eslint-plugin-square/pull/241).

