### PR TITLE
Mention other common linters not included by this plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the relevant lint scripts in `package.json`:
 }
 ```
 
-And be sure to run linting:
+Configure linting to run:
 
 * As a build check during CI
 * In your precommit hook (see [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky))
@@ -99,6 +99,18 @@ Note that we prefer to upstream our custom lint rules to third-party ESLint plug
 [strict]: lib/config/strict.js
 [typescript]: lib/config/typescript.js
 [@typescript-eslint/parser]: https://www.npmjs.com/package/@typescript-eslint/parser
+
+## Related
+
+Consider adding other linters not included by plugin:
+
+* [check-dependency-version-consistency](https://github.com/bmish/check-dependency-version-consistency) for monorepos
+* [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) for handlebars files
+* [eslint-plugin-markdown](https://github.com/eslint/eslint-plugin-markdown) for markdown code samples
+* [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node) for Node files
+* [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) for markdown documentation formatting
+* [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) for package.json
+* [stylelint](https://github.com/stylelint/stylelint) for CSS files
 
 ## License
 


### PR DESCRIPTION
While eslint-plugin-square bundles a lot of common JS/TS linters, there are some common linters that it does not include.

For ESLint plugins that are not included like eslint-plugin-markdown and eslint-plugin-node, this is usually because it could be hard for us to automatically configure them to run seamlessly on the right files (they're usually configured on specific files via an override and may need some customization).

And then there are linters for other file types (non-JS/TS) that are not included because eslint-plugin-square is purely an ESLint plugin.

So while we won't include every linter, we can still mention some common ones in a "Related" section of the README. The criteria for inclusion here is that these are linters commonly used alongside eslint-plugin-square in the types of applications that eslint-plugin-square is typically used for (e.g. Ember, React, or TypeScript applications).

Note that I've included in the list a couple of linters that I maintain because these are either standard in Ember apps ([ember-template-lint](https://github.com/ember-template-lint/ember-template-lint)) or I've successfully introduced them in various repositories across the company already ([check-dependency-version-consistency](https://github.com/bmish/check-dependency-version-consistency)).

