### PR TITLE
`paths` option is now optional in `no-restricted-files` rule

### DIFF
--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -4,18 +4,41 @@ This rule can be used to disallow files at certain file paths.
 
 ## Examples
 
-For example, we may want to disallow unscoped/unnested components, and instead require that each component is nested or scoped within a folder.
+Example `.eslintrc.js` using the rule's `paths` option for matching files based on a regexp pattern:
 
-Regexp: `app/components/[^/]+$`
+```js
+module.exports = {
+  rules: {
+    'square/no-restricted-files': [
+      'error',
+      {
+        paths: ['app/components/[^/]+$'],
+        message: 'Use a nested scope instead of adding new components to the top-level components folder.',
+      },
+    ]
+  }
+};
+```
 
-Disallows this unscoped component: `app/components/my-component.js`
+Example `.eslintrc.js` using ESLint's built-in [overrides feature](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) for matching files based on a glob pattern:
 
-Allows this scoped component: `app/components/scope/my-component.js`
+```js
+module.exports = {
+  overrides: [
+    {
+      files: ['bad/place/to/add/js/files/**/*.js'],
+      rules: {
+        'square/no-restricted-files': ['error', [{ message: 'Do not add JS files here for x reason.' }]],
+      },
+    },
+  ],
+};
+```
 
 ## Configuration
 
 * object[] -- containing the following properties:
-  * string[] -- `paths` -- list of regexp file paths to disallow
+  * string[] -- `paths` -- optional list of regexp file paths to disallow (if you want to use glob patterns, use ESLint's built-in [glob pattern overrides feature](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead of this)
   * string -- `message` -- optional custom error message to display for these disallowed file paths
 
 ## Migration

--- a/lib/rules/no-restricted-files.js
+++ b/lib/rules/no-restricted-files.js
@@ -11,11 +11,9 @@ module.exports = {
     },
     schema: {
       type: 'array',
-      minItems: 1,
       uniqueItems: true,
       items: {
         type: 'object',
-        required: ['paths'],
         properties: {
           message: {
             type: 'string',
@@ -40,17 +38,21 @@ module.exports = {
   create(context) {
     return {
       Program(node) {
-        /** @type {{message?:string,paths:string[]}[]} */
+        /** @type {{message?:string,paths?:string[]}[]} */
         const config = context.options;
-        const match = config.find((option) =>
-          option.paths.some((path) => context.getFilename().match(path))
+        const match = config.find(
+          (option) =>
+            !option.paths ||
+            option.paths.some(
+              (path) => !path || context.getFilename().match(path)
+            )
         );
-        if (match) {
+        if (match || config.length === 0) {
           context.report({
             node,
-            // @ts-ignore -- `messageId` is optional.
-            messageId: match.message ? undefined : 'defaultError',
-            message: match.message, // eslint-disable-line eslint-plugin/prefer-message-ids
+            // @ts-expect-error -- `messageId` is optional.
+            messageId: match?.message ? undefined : 'defaultError',
+            message: match?.message || undefined, // eslint-disable-line eslint-plugin/prefer-message-ids
             // Uncomment this autofixer to grandfather in existing files.
             // fix(fixer) {
             //   return fixer.insertTextBefore(

--- a/tests/lib/rules/no-restricted-files.js
+++ b/tests/lib/rules/no-restricted-files.js
@@ -23,10 +23,19 @@ ruleTester.run('no-restricted-files', rule, {
   ],
   invalid: [
     {
+      // With paths only.
       filename: FILEPATH_UNSCOPED_COMPONENT,
       code: 'const x = 123;',
       output: null,
       options: [{ paths: [REGEXP_DISALLOW_UNSCOPED_COMPONENTS] }],
+      errors: [{ messageId: 'defaultError', type: 'Program' }],
+    },
+    {
+      // Multiple paths.
+      filename: FILEPATH_UNSCOPED_COMPONENT,
+      code: 'const x = 123;',
+      output: null,
+      options: [{ paths: ['foo-[0-9]', REGEXP_DISALLOW_UNSCOPED_COMPONENTS] }],
       errors: [{ messageId: 'defaultError', type: 'Program' }],
     },
     {
@@ -56,6 +65,19 @@ ruleTester.run('no-restricted-files', rule, {
           message: 'No unscoped components.',
         },
       ],
+      errors: [{ message: 'No unscoped components.', type: 'Program' }],
+    },
+    {
+      // No options, should disallow every file.
+      code: 'const x = 123;',
+      output: null,
+      errors: [{ messageId: 'defaultError', type: 'Program' }],
+    },
+    {
+      // Only message specified, should disallow every file.
+      code: 'const x = 123;',
+      output: null,
+      options: [{ message: 'No unscoped components.' }],
       errors: [{ message: 'No unscoped components.', type: 'Program' }],
     },
   ],


### PR DESCRIPTION
The `paths` option is useful if you want to use regexp to match filenames to disallow. If you want to instead use glob patterns, ESLint's built-in [glob pattern overrides feature](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) should be used, and `paths` shouldn't be needed. This change optimizes the rule for the glob-based use-case so you don't have to specify a wildcard like `paths: ['.+']`.