### PR TITLE
Switch to dash for markdown lists

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,6 @@
 {
-  "line-length": false
+  "line-length": false,
+  "ul-style": {
+    "style": "dash"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 
 ## Requirements
 
-* [ESLint](https://eslint.org/) `>= 8.18.0`
-* [Node.js](https://nodejs.org/) `^14.18.0 || ^16.0.0 || >= 18.0.0`
+- [ESLint](https://eslint.org/) `>= 8.18.0`
+- [Node.js](https://nodejs.org/) `^14.18.0 || ^16.0.0 || >= 18.0.0`
 
 ## Usage
 
@@ -40,32 +40,32 @@ Add the relevant lint scripts in `package.json` with [npm-run-all](https://githu
 
 Configure linting to run:
 
-* With the ESLint extension for your IDE
-* In your precommit hook (see [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky))
-* As a build check during CI (in case IDE warnings or the precommit hook are bypassed)
+- With the ESLint extension for your IDE
+- In your precommit hook (see [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky))
+- As a build check during CI (in case IDE warnings or the precommit hook are bypassed)
 
 Fix violations using:
 
-* Lint rule autofixers (`eslint --fix`)
-* Lint rule suggestions (a fixer option provided by some rules on highlighted violations in IDEs)
-* Codemods (sometimes provided for larger codebase transformations)
-* Find-and-replace (with RegExp if necessary)
-* Manual fixes
+- Lint rule autofixers (`eslint --fix`)
+- Lint rule suggestions (a fixer option provided by some rules on highlighted violations in IDEs)
+- Codemods (sometimes provided for larger codebase transformations)
+- Find-and-replace (with RegExp if necessary)
+- Manual fixes
 
 Sometimes, you may not want to fix certain violations, for reasons such as:
 
-* Some code is too risky to change
-* A rule may have too many violations and fixing is too tedious / manual
-* A rule may have false positives and flag legitimate code
-* A rule may not apply in all circumstances (such as a rule that is only useful for test code)
-* You may prefer to follow different conventions/styles in your codebase
-* You may want to follow-up later to address a specific rule in its own PR
+- Some code is too risky to change
+- A rule may have too many violations and fixing is too tedious / manual
+- A rule may have false positives and flag legitimate code
+- A rule may not apply in all circumstances (such as a rule that is only useful for test code)
+- You may prefer to follow different conventions/styles in your codebase
+- You may want to follow-up later to address a specific rule in its own PR
 
 If you prefer not to adopt a specific rule, you can disable it:
 
-* Globally (in the global configuration file)
-* In specific directories (in an override in the global configuration file)
-* In specific files or on specific lines using comments (`// eslint-disable-line no-empty-function`)
+- Globally (in the global configuration file)
+- In specific directories (in an override in the global configuration file)
+- In specific files or on specific lines using comments (`// eslint-disable-line no-empty-function`)
 
 ## Configurations
 
@@ -79,17 +79,17 @@ If you prefer not to adopt a specific rule, you can disable it:
 
 Rules enabled by these configurations should meet the following criteria:
 
-* They make sense in a wide variety of codebases (and have been tested in a variety of Square's applications).
-* They are generally acceptable and desirable (in terms of enforcing best practices, consistency, avoiding bugs) to most developers.
-* There is a practical migration path (autofixers, codemod, find-and-replace, manual fixes) for enabling them in most applications.
+- They make sense in a wide variety of codebases (and have been tested in a variety of Square's applications).
+- They are generally acceptable and desirable (in terms of enforcing best practices, consistency, avoiding bugs) to most developers.
+- There is a practical migration path (autofixers, codemod, find-and-replace, manual fixes) for enabling them in most applications.
 
 ## Custom rules
 
 Each rule has emojis denoting:
 
-* What configuration it belongs to
-* 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
-* 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
+- What configuration it belongs to
+- 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
+- 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
 | Name    | Category | 🔥 | 🔧 | 💡 |
 | :------ | :------- | :-- | :-- | :-- |
@@ -105,19 +105,19 @@ Each rule has emojis denoting:
 
 Note that we prefer to upstream our custom lint rules to third-party ESLint plugins whenever possible. The rules that still remain here are typically here because:
 
-* We haven't found the appropriate ESLint plugin to upstream them to.
-* We haven't found the time to upstream them.
-* They are specific to Square in some way / not generic enough.
+- We haven't found the appropriate ESLint plugin to upstream them to.
+- We haven't found the time to upstream them.
+- They are specific to Square in some way / not generic enough.
 
 If you do need to write a custom lint rule here because you can't find an existing lint rule to use or other ESLint plugin to contribute to, be sure to consult [astexplorer.net](https://astexplorer.net/) while writing it.
 
 Lint rule ideas often come from:
 
-* A source of frequent "nit" comments in PRs
-* Common issues that newcomers stumble on
-* Code that indicates a bug, mistake, or bad practice
-* Inconsistencies throughout the codebase
-* Outdated / obsolete / legacy code
+- A source of frequent "nit" comments in PRs
+- Common issues that newcomers stumble on
+- Code that indicates a bug, mistake, or bad practice
+- Inconsistencies throughout the codebase
+- Outdated / obsolete / legacy code
 
 [base]: lib/config/base.js
 [ember]: lib/config/ember.js
@@ -138,14 +138,14 @@ Lint rule ideas often come from:
 
 Consider adding other linters not included by plugin:
 
-* [check-dependency-version-consistency](https://github.com/bmish/check-dependency-version-consistency) for monorepos
-* [commitlint](https://github.com/conventional-changelog/commitlint)
-* [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) for handlebars files
-* [eslint-plugin-markdown](https://github.com/eslint/eslint-plugin-markdown) for markdown code samples
-* [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node) for Node files
-* [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) for markdown documentation formatting
-* [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) for package.json
-* [stylelint](https://github.com/stylelint/stylelint) for CSS files
+- [check-dependency-version-consistency](https://github.com/bmish/check-dependency-version-consistency) for monorepos
+- [commitlint](https://github.com/conventional-changelog/commitlint)
+- [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) for handlebars files
+- [eslint-plugin-markdown](https://github.com/eslint/eslint-plugin-markdown) for markdown code samples
+- [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node) for Node files
+- [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) for markdown documentation formatting
+- [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) for package.json
+- [stylelint](https://github.com/stylelint/stylelint) for CSS files
 
 ## License
 

--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -32,24 +32,24 @@ Examples of **correct** code for this rule:
 
 TODO: suggest any fast/automated techniques for fixing violations in a large codebase
 
-* TODO: suggestion on how to fix violations using find-and-replace / regexp
-* TODO: suggestion on how to fix violations using a codemod
+- TODO: suggestion on how to fix violations using find-and-replace / regexp
+- TODO: suggestion on how to fix violations using a codemod
 
 ## Configuration
 
 TODO: exclude this section if the rule has no extra configuration
 
-* object -- containing the following properties:
-  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+- object -- containing the following properties:
+  - string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
+  - boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
 
 ## Related Rules
 
-* [TODO-related-rule-name1](related-rule-name1.md)
-* [TODO-related-rule-name2](related-rule-name2.md)
+- [TODO-related-rule-name1](related-rule-name1.md)
+- [TODO-related-rule-name2](related-rule-name2.md)
 
 ## References
 
-* TODO: link to relevant documentation goes here
-* TODO: link to relevant function spec goes here
-* TODO: link to relevant guide goes here
+- TODO: link to relevant documentation goes here
+- TODO: link to relevant function spec goes here
+- TODO: link to relevant guide goes here

--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -46,6 +46,6 @@ test('the element exists', function (assert) {
 
 ## References
 
-* See the [documentation](https://guides.emberjs.com/v2.14.0/testing/acceptance/) for Ember's `find` acceptance test helper
-* See the [documentation](https://github.com/simplabs/qunit-dom) for the `qunit-dom` package
-* Related rule: [qunit-dom/no-ok-find](https://github.com/simplabs/eslint-plugin-qunit-dom/blob/main/rules/no-ok-find.md)
+- See the [documentation](https://guides.emberjs.com/v2.14.0/testing/acceptance/) for Ember's `find` acceptance test helper
+- See the [documentation](https://github.com/simplabs/qunit-dom) for the `qunit-dom` package
+- Related rule: [qunit-dom/no-ok-find](https://github.com/simplabs/eslint-plugin-qunit-dom/blob/main/rules/no-ok-find.md)

--- a/docs/rules/no-missing-tests.md
+++ b/docs/rules/no-missing-tests.md
@@ -32,8 +32,8 @@ const config = {
 
 Example implementation file and test file pair that would be enforced:
 
-* `app/components/my-component.js`
-* `tests/unit/components/my-component-test.js`
+- `app/components/my-component.js`
+- `tests/unit/components/my-component-test.js`
 
 ## Migration
 
@@ -41,7 +41,7 @@ There's an autofixer in the rule implementation that can be uncommented as desir
 
 ## Configuration
 
-* object[]
-  * string -- `filePath` -- path to files that should have tests
-  * string[] -- `testPaths` -- paths to possible test file locations to check
-  * boolean -- `hasTestSuffix` -- whether the test files end in `-test` (default true)
+- object[]
+  - string -- `filePath` -- path to files that should have tests
+  - string[] -- `testPaths` -- paths to possible test file locations to check
+  - boolean -- `hasTestSuffix` -- whether the test files end in `-test` (default true)

--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -37,9 +37,9 @@ module.exports = {
 
 ## Configuration
 
-* object[] -- containing the following properties:
-  * string[] -- `paths` -- optional list of regexp file paths to disallow (if you want to use glob patterns, use ESLint's built-in [glob pattern overrides feature](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead of this)
-  * string -- `message` -- optional custom error message to display for these disallowed file paths
+- object[] -- containing the following properties:
+  - string[] -- `paths` -- optional list of regexp file paths to disallow (if you want to use glob patterns, use ESLint's built-in [glob pattern overrides feature](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead of this)
+  - string -- `message` -- optional custom error message to display for these disallowed file paths
 
 ## Migration
 

--- a/docs/rules/no-test-return-value.md
+++ b/docs/rules/no-test-return-value.md
@@ -44,5 +44,5 @@ test('it does something', function (assert) {
 
 ## Configuration
 
-* object -- containing the following properties:
-  * `String[]` -- `testHooks` -- optional array of test hook names to use (see rule implementation for the default list)
+- object -- containing the following properties:
+  - `String[]` -- `testHooks` -- optional array of test hook names to use (see rule implementation for the default list)

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -39,11 +39,11 @@ function getStatusString(status) {
 
 This rule takes an optional object containing:
 
-* `string` -- `serviceName` -- optional override for service name to look for (default is `intl`)
-* `boolean` -- `enforceStringLiteralKeys` -- optional override to restrict translation keys to only string literals (when disabled, function calls and variables are allowed) (default is `false`)
+- `string` -- `serviceName` -- optional override for service name to look for (default is `intl`)
+- `boolean` -- `enforceStringLiteralKeys` -- optional override to restrict translation keys to only string literals (when disabled, function calls and variables are allowed) (default is `false`)
 
 ## References
 
-* [Service API](https://ember-intl.github.io/ember-intl/versions/v4.0.0/docs/guide/ember-service-api) for [ember-intl]
+- [Service API](https://ember-intl.github.io/ember-intl/versions/v4.0.0/docs/guide/ember-service-api) for [ember-intl]
 
 [ember-intl]: https://github.com/ember-intl/ember-intl

--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -10,9 +10,9 @@ Some functions are asynchronous and you may want to wait for their code to finis
 
 This lint rule requires that specified functions be called with the `await` keyword. The benefits of this include:
 
-* Ensure code runs in the right (deterministic) order
-* Promote cleaner code by reducing unwieldy promise chain usage
-* Enforce a consistent way of calling/chaining asynchronous functions
+- Ensure code runs in the right (deterministic) order
+- Promote cleaner code by reducing unwieldy promise chain usage
+- Enforce a consistent way of calling/chaining asynchronous functions
 
 Note: this rule does not require using `await` in return statements or when nested inside other function calls.
 
@@ -57,28 +57,28 @@ test('clicking the button sends the action', async function (assert) {
 
 This rule accepts a single argument:
 
-* Set the required `functions` option to an array of the function names that must be called with `await`.
+- Set the required `functions` option to an array of the function names that must be called with `await`.
 
 ## Migration
 
-* [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
-* [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule
+- [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
+- [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule
 
 ## When Not To Use It
 
 You should avoid enabling this rule if:
 
-* Your JavaScript/browser environment does not support `async` functions (an ES8/ES2017 feature)
-* You have no asynchronous functions
-* You prefer to use promise chains instead of the `async` keyword
+- Your JavaScript/browser environment does not support `async` functions (an ES8/ES2017 feature)
+- You have no asynchronous functions
+- You prefer to use promise chains instead of the `async` keyword
 
 ## Related Rules
 
-* [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop.md)
-* [no-return-await](https://eslint.org/docs/rules/no-return-await.md)
-* [require-atomic-updates](https://eslint.org/docs/rules/require-atomic-updates.md)
-* [require-await](https://eslint.org/docs/rules/require-await.md)
+- [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop.md)
+- [no-return-await](https://eslint.org/docs/rules/no-return-await.md)
+- [require-atomic-updates](https://eslint.org/docs/rules/require-atomic-updates.md)
+- [require-await](https://eslint.org/docs/rules/require-await.md)
 
 ## Resources
 
-* See the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) for async functions
+- See the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) for async functions

--- a/docs/rules/use-call-count-test-assert.md
+++ b/docs/rules/use-call-count-test-assert.md
@@ -10,11 +10,11 @@ Using `callCount` rather than the other shortcut count helpers (such as `calledO
 
 This lint rule prevents the use of:
 
-* `notCalled`
-* `calledOnce`
-* `calledTwice`
-* `calledThrice`
-* `called`
+- `notCalled`
+- `calledOnce`
+- `calledTwice`
+- `calledThrice`
+- `called`
 
 The above do not provide as much information to the test runner.
 
@@ -38,4 +38,4 @@ test('it works', function (assert) {
 
 ## Resources
 
-* See the [documentation](https://sinonjs.org/releases/latest/spies/) for spies and their properties
+- See the [documentation](https://sinonjs.org/releases/latest/spies/) for spies and their properties

--- a/docs/rules/use-ember-find.md
+++ b/docs/rules/use-ember-find.md
@@ -32,9 +32,9 @@ find('.my-selector');
 
 ## Related Rules
 
-* [no-jquery](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-jquery.md)
+- [no-jquery](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-jquery.md)
 
 ## References
 
-* See the [documentation](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find) for Ember's `find` test helper
-* See the [Ember Application Tests](https://guides.emberjs.com/release/testing/acceptance/) guide
+- See the [documentation](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find) for Ember's `find` test helper
+- See the [Ember Application Tests](https://guides.emberjs.com/release/testing/acceptance/) guide


### PR DESCRIPTION
Before this change, whatever list style was used first in a file would be enforced for that file. Now, let's standardize on dashes. This is all autofixed by the lint rule.

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md004---unordered-list-style

This is also the [standard enforced by prettier for markdown](https://github.com/prettier/prettier/issues/4251) which we may adopt later.