### PR TITLE
Automate docs with eslint-doc-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ If you prefer not to adopt a specific rule, you can disable it:
 
 |     | Name | Description |
 | --- | --- | --- |
-| | [base] | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], [eslint-plugin-unicorn], and more. |
-| 🔥 | [ember] | [Ember.js]-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
-| | [react] | [React](https://reactjs.org)-specific additions on top of `base`. |
-| | [strict] | A variety of stricter lint rules on top of `base`. |
-| | [typescript] | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
+| | [base](lib/config/base.js) | Rules and configuration for any JavaScript-based project. Includes recommended and optional rules from [eslint], [prettier], [eslint-plugin-eslint-comments], [eslint-plugin-import], [eslint-plugin-unicorn], and more. |
+| 🔥 | [ember](lib/config/ember.js) | [Ember.js](https://www.emberjs.com/)-specific additions on top of `base`. Includes recommended and optional rules from [eslint-plugin-ember], kebab-case filename enforcement with [eslint-plugin-filenames], and more. |
+| | [react](lib/config/react.js) | [React](https://reactjs.org/)-specific additions on top of `base`. |
+| | [strict](lib/config/strict.js) | A variety of stricter lint rules on top of `base`. |
+| | [typescript](lib/config/typescript.js) | [TypeScript](https://www.typescriptlang.org/)-specific additions on top of `base`. Use with [@typescript-eslint/parser]. |
 
 Rules enabled by these configurations should meet the following criteria:
 
@@ -85,23 +85,27 @@ Rules enabled by these configurations should meet the following criteria:
 
 ## Custom rules
 
-Each rule has emojis denoting:
+🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option \
+💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
-- What configuration it belongs to
-- 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
-- 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
+<!-- begin rules list -->
 
-| Name    | Category | 🔥 | 🔧 | 💡 |
-| :------ | :------- | :-- | :-- | :-- |
-| [no-assert-ok-find](docs/rules/no-assert-ok-find.md) | Ember Testing | 🔥 | | 💡 |
-| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md) | Ember | | | |
-| [no-missing-tests](docs/rules/no-missing-tests.md) | Testing | | | |
-| [no-restricted-files](docs/rules/no-restricted-files.md) | JavaScript | | | |
-| [no-test-return-value](docs/rules/no-test-return-value.md) | Testing | 🔥 | | 💡 |
-| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | Ember | 🔥 | | |
-| [require-await-function](docs/rules/require-await-function.md) | JavaScript | 🔥 | 🔧 | |
-| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md) | Testing | 🔥 | 🔧 | |
-| [use-ember-find](docs/rules/use-ember-find.md) | Ember Testing | 🔥 | 🔧 | |
+| Rule                                                                               | Description                                                                              | 💼                     | 🔧  | 💡  |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- | --- | --- |
+| [no-assert-ok-find](docs/rules/no-assert-ok-find.md)                               | disallow usage of `assert.ok(find(...))` as it will always pass                          | ![ember][]             |     | 💡  |
+| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md)             | disallow unsafe HTML in strings/hbs/translations                                         |                        |     |     |
+| [no-missing-tests](docs/rules/no-missing-tests.md)                                 | disallow files without a corresponding test file                                         |                        |     |     |
+| [no-restricted-files](docs/rules/no-restricted-files.md)                           | disallow files with a path matching a specific regexp                                    |                        |     |     |
+| [no-test-return-value](docs/rules/no-test-return-value.md)                         | disallow test functions with a return value                                              | ![ember][]             |     | 💡  |
+| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | disallow string interpolation in translation keys                                        | ![ember][]             |     |     |
+| [require-await-function](docs/rules/require-await-function.md)                     | enforce using `await` with calls to specified functions                                  | ![ember][]             | 🔧  |     |
+| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md)             | enforce using `assert.equal(...callCount, ...);` instead of `assert.ok(...calledOnce);`  | ![ember][] ![strict][] | 🔧  |     |
+| [use-ember-find](docs/rules/use-ember-find.md)                                     | require use of Ember's `find` helper instead of `jQuery` for selecting elements in tests | ![ember][]             | 🔧  |     |
+
+<!-- end rules list -->
+
+[ember]: https://img.shields.io/badge/-ember-orange.svg
+[strict]: https://img.shields.io/badge/-strict-black.svg
 
 Note that we prefer to upstream our custom lint rules to third-party ESLint plugins whenever possible. The rules that still remain here are typically here because:
 
@@ -119,9 +123,6 @@ Lint rule ideas often come from:
 - Inconsistencies throughout the codebase
 - Outdated / obsolete / legacy code
 
-[base]: lib/config/base.js
-[ember]: lib/config/ember.js
-[Ember.js]: https://www.emberjs.com/
 [eslint]: https://eslint.org/
 [eslint-plugin-ember]: https://github.com/ember-cli/eslint-plugin-ember
 [eslint-plugin-eslint-comments]: https://github.com/mysticatea/eslint-plugin-eslint-comments
@@ -129,10 +130,7 @@ Lint rule ideas often come from:
 [eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import
 [eslint-plugin-unicorn]: https://github.com/sindresorhus/eslint-plugin-unicorn
 [prettier]: https://prettier.io/
-[react]: lib/config/react.js
-[strict]: lib/config/strict.js
-[typescript]: lib/config/typescript.js
-[@typescript-eslint/parser]: https://www.npmjs.com/package/@typescript-eslint/parser
+[@typescript-eslint/parser]: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser
 
 ## Related
 

--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -1,8 +1,10 @@
-# no-assert-ok-find
+# Disallow usage of `assert.ok(find(...))` as it will always pass (`square/no-assert-ok-find`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`.
 
-💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+💡 This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions) that can be applied manually.
+
+<!-- end rule header -->
 
 Ember's old built-in `find('.selector')` acceptance test helper function always returns an array, even when no elements match. As a result, `assert.ok(find('.selector'))` will always pass, even if no elements are found, as an empty array is still truthy.
 

--- a/docs/rules/no-handlebar-interpolation.md
+++ b/docs/rules/no-handlebar-interpolation.md
@@ -1,4 +1,6 @@
-# no-handlebar-interpolation
+# Disallow unsafe HTML in strings/hbs/translations (`square/no-handlebar-interpolation`)
+
+<!-- end rule header -->
 
 This rule disallows "no-handlebar-interpolation" `{{{` in strings which is assumed to be used to insert unsafe HTML.
 

--- a/docs/rules/no-missing-tests.md
+++ b/docs/rules/no-missing-tests.md
@@ -1,4 +1,6 @@
-# no-missing-tests
+# Disallow files without a corresponding test file (`square/no-missing-tests`)
+
+<!-- end rule header -->
 
 Ensuring that files have corresponding test files can be helpful towards improving test coverage.
 

--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -1,4 +1,6 @@
-# no-restricted-files
+# Disallow files with a path matching a specific regexp (`square/no-restricted-files`)
+
+<!-- end rule header -->
 
 This rule can be used to disallow files at certain file paths.
 

--- a/docs/rules/no-test-return-value.md
+++ b/docs/rules/no-test-return-value.md
@@ -1,10 +1,10 @@
-# no-test-return-value
+# Disallow test functions with a return value (`square/no-test-return-value`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`.
 
-💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+💡 This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions) that can be applied manually.
 
-This rule disallows test functions with return values.
+<!-- end rule header -->
 
 For asynchronous tests, use async/await instead of returning a promise.
 

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -1,6 +1,8 @@
-# no-translation-key-interpolation
+# Disallow string interpolation in translation keys (`square/no-translation-key-interpolation`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`.
+
+<!-- end rule header -->
 
 Using string interpolation for constructing translation keys makes it difficult to search for them to determine where and if they are used.
 

--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -1,8 +1,10 @@
-# require-await-function
+# Enforce using `await` with calls to specified functions (`square/require-await-function`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`.
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+
+<!-- end rule header -->
 
 Some functions are asynchronous and you may want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help you achieve this.
 

--- a/docs/rules/use-call-count-test-assert.md
+++ b/docs/rules/use-call-count-test-assert.md
@@ -1,8 +1,10 @@
-# use-call-count-test-assert
+# Enforce using `assert.equal(...callCount, ...);` instead of `assert.ok(...calledOnce);` (`square/use-call-count-test-assert`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`, `strict`.
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+
+<!-- end rule header -->
 
 Using `callCount` rather than the other shortcut count helpers (such as `calledOnce`, `notCalled`) allows the test runner to show the actual number of times the spy was called.
 

--- a/docs/rules/use-ember-find.md
+++ b/docs/rules/use-ember-find.md
@@ -1,8 +1,10 @@
-# use-ember-find
+# Require use of Ember's `find` helper instead of `jQuery` for selecting elements in tests (`square/use-ember-find`)
 
-🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.
+💼 This rule is enabled in the following configs: `ember`.
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+
+<!-- end rule header -->
 
 It is preferred to use Ember test helpers like `find(selector)` instead of jQuery for selecting elements in tests.
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint \"**/*.md\"",
+    "lint:eslint-docs": "npm-run-all update:eslint-docs && git diff --exit-code",
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
@@ -35,7 +36,8 @@
     "prepublishOnly": "tsc",
     "preversion": "yarn test && yarn lint",
     "release": "release-it",
-    "test": "nyc --all --check-coverage mocha --recursive tests"
+    "test": "nyc --all --check-coverage mocha --recursive tests",
+    "update:eslint-docs": "eslint-doc-generator"
   },
   "prettier": "@square/prettier-config",
   "nyc": {
@@ -74,6 +76,7 @@
     "@types/requireindex": "^1.2.0",
     "@typescript-eslint/parser": "^5.37.0",
     "eslint": "^8.24.0",
+    "eslint-doc-generator": "^0.3.5",
     "eslint-plugin-eslint-plugin": "^5.0.6",
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -11,30 +11,6 @@ const RULE_NAMES = Object.keys(rules);
 const RULE_NAMES_EMBER = new Set(Object.keys(configEmber.rules));
 RULE_NAMES_EMBER.add('square/require-await-function'); // This rule is enabled in an override.
 
-/**
- * @param {import('json-schema').JSONSchema4} jsonSchema
- * @returns {string[]}
- */
-function getAllNamedOptions(jsonSchema) {
-  if (!jsonSchema) {
-    return [];
-  }
-
-  if (Array.isArray(jsonSchema)) {
-    return jsonSchema.flatMap((item) => getAllNamedOptions(item));
-  }
-
-  if (jsonSchema.items) {
-    return getAllNamedOptions(jsonSchema.items);
-  }
-
-  if (jsonSchema.properties) {
-    return Object.keys(jsonSchema.properties);
-  }
-
-  return [];
-}
-
 describe('rules setup is correct', function () {
   it('should have a list of exported rules and rules directory that match', function () {
     const filePath = path.join(__dirname, '..', 'lib', 'rules');
@@ -95,98 +71,6 @@ describe('rules setup is correct', function () {
               file.includes(TYPE_ANNOTATION_UNCLOSED),
             `includes jsdoc comment for rule type: ${TYPE_ANNOTATION}`
           );
-        });
-      });
-    }
-  });
-
-  describe('rule documentation files', function () {
-    const CONFIG_MSG_EMBER =
-      '🔥 The `"extends": "plugin:square/ember"` property in a configuration file enables this rule.';
-
-    const FIXABLE =
-      '🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.';
-
-    const HAS_SUGGESTIONS =
-      '💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).';
-
-    for (const ruleName of RULE_NAMES) {
-      const rule = rules[ruleName];
-      const filePath = path.join(
-        __dirname,
-        '..',
-        'docs',
-        'rules',
-        `${ruleName}.md`
-      );
-      const file = readFileSync(filePath, 'utf8');
-
-      describe(ruleName, function () {
-        it('should have the right contents (title, examples, fixable notice)', function () {
-          assert.ok(file.includes(`# ${ruleName}`), 'includes title header');
-          assert.ok(
-            file.includes('## Examples'),
-            'includes example section header'
-          );
-
-          // Check if the rule has configuration options.
-          if (
-            (Array.isArray(rule.meta.schema) && rule.meta.schema.length > 0) ||
-            (typeof rule.meta.schema === 'object' &&
-              Object.keys(rule.meta.schema).length > 0)
-          ) {
-            // Should have a configuration section header:
-            assert.ok(
-              file.includes('## Configuration'),
-              'has a "Configuration" section'
-            );
-
-            // Ensure all configuration options are mentioned.
-            for (const namedOption of getAllNamedOptions(rule.meta.schema)) {
-              assert.ok(
-                file.includes(namedOption),
-                `mentions rule option ${namedOption}`
-              );
-            }
-          } else {
-            assert.ok(
-              !file.includes('## Configuration'),
-              'does not have a "Configuration" section'
-            );
-          }
-
-          if (rule.meta.fixable) {
-            assert.ok(file.includes(FIXABLE), 'includes fixable notice');
-          } else {
-            assert.ok(
-              !file.includes(FIXABLE),
-              'does not include fixable notice'
-            );
-          }
-
-          if (RULE_NAMES_EMBER.has(`square/${ruleName}`)) {
-            assert.ok(
-              file.includes(CONFIG_MSG_EMBER),
-              'has `ember` config notice'
-            );
-          } else {
-            assert.ok(
-              !file.includes(CONFIG_MSG_EMBER),
-              'does not have `ember` config notice'
-            );
-          }
-
-          if (rule.meta.hasSuggestions) {
-            assert.ok(
-              file.includes(HAS_SUGGESTIONS),
-              'includes suggestions notice'
-            );
-          } else {
-            assert.ok(
-              !file.includes(HAS_SUGGESTIONS),
-              'does not include suggestions notice'
-            );
-          }
         });
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,6 +886,14 @@
     "@typescript-eslint/types" "5.37.0"
     "@typescript-eslint/visitor-keys" "5.37.0"
 
+"@typescript-eslint/scope-manager@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz#873e1465afa3d6c78d8ed2da68aed266a08008d0"
+  integrity sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==
+  dependencies:
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/visitor-keys" "5.39.0"
+
 "@typescript-eslint/type-utils@5.37.0":
   version "5.37.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz#43ed2f567ada49d7e33a6e4b6f9babd060445fe5"
@@ -901,6 +909,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.37.0.tgz#09e4870a5f3af7af3f84e08d792644a87d232261"
   integrity sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==
 
+"@typescript-eslint/types@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.39.0.tgz#f4e9f207ebb4579fd854b25c0bf64433bb5ed78d"
+  integrity sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==
+
 "@typescript-eslint/typescript-estree@5.37.0":
   version "5.37.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz#956dcf5c98363bcb97bdd5463a0a86072ff79355"
@@ -908,6 +921,19 @@
   dependencies:
     "@typescript-eslint/types" "5.37.0"
     "@typescript-eslint/visitor-keys" "5.37.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz#c0316aa04a1a1f4f7f9498e3c13ef1d3dc4cf88b"
+  integrity sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==
+  dependencies:
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/visitor-keys" "5.39.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -926,12 +952,32 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@^5.38.1":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.39.0.tgz#b7063cca1dcf08d1d21b0d91db491161ad0be110"
+  integrity sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.39.0"
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/typescript-estree" "5.39.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@5.37.0":
   version "5.37.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz#7b72dd343295ea11e89b624995abc7103c554eee"
   integrity sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==
   dependencies:
     "@typescript-eslint/types" "5.37.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz#8f41f7d241b47257b081ddba5d3ce80deaae61e2"
+  integrity sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==
+  dependencies:
+    "@typescript-eslint/types" "5.39.0"
     eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -1530,6 +1576,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
+
 commander@~9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
@@ -2002,6 +2053,15 @@ eslint-config-prettier@^8.4.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
+eslint-doc-generator@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-0.3.5.tgz#e1828528faa3acd0f7dcc8ea52e2d5858decf89a"
+  integrity sha512-jNyIyGHDOxDeAA9WVZMYNoU3Rkzyp0eOBtWwave3N5eig14bE/UT96SYSKEwAFnmn9ipjHm5U4BjsBzs+t7dxw==
+  dependencies:
+    "@typescript-eslint/utils" "^5.38.1"
+    commander "^9.4.0"
+    type-fest "^3.0.0"
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -5973,6 +6033,11 @@ type-fest@^2.12.0, type-fest@^2.13.0, type-fest@^2.5.1:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
   integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
+
+type-fest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.0.0.tgz#678e2e8d916e3b7dc1c3a6591d399ba3f7521584"
+  integrity sha512-MINvUN5ug9u+0hJDzSZNSnuKXI8M4F5Yvb6SQZ2CYqe7SgKXKOosEcU5R7tRgo85I6eAVBbkVF7TCvB4AUK2xQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
I built this CLI tool [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) for automating the README rules list and the title/notices in each rule doc. It follows common documentation conventions from other ESLint plugins. The goal is to improve the usability of our custom rules through better documentation and make it easier to add new rules by automating more of the process. I was also able to remove tests that are now redundant.