### PR TITLE
Update eslint-doc-generator to 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,27 +85,27 @@ Rules enabled by these configurations should meet the following criteria:
 
 ## Custom rules
 
-🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option \
-💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
+<!-- begin auto-generated rules list -->
 
-<!-- begin rules list -->
+💼 [Configurations](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations) enabled in.\
+🔥 Enabled in the `ember` [configuration](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).\
+🔒 Enabled in the `strict` [configuration](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).\
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Rule                                                                               | Description                                                                              | 💼                     | 🔧  | 💡  |
-| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- | --- | --- |
-| [no-assert-ok-find](docs/rules/no-assert-ok-find.md)                               | disallow usage of `assert.ok(find(...))` as it will always pass                          | ![ember][]             |     | 💡  |
-| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md)             | disallow unsafe HTML in strings/hbs/translations                                         |                        |     |     |
-| [no-missing-tests](docs/rules/no-missing-tests.md)                                 | disallow files without a corresponding test file                                         |                        |     |     |
-| [no-restricted-files](docs/rules/no-restricted-files.md)                           | disallow files with a path matching a specific regexp                                    |                        |     |     |
-| [no-test-return-value](docs/rules/no-test-return-value.md)                         | disallow test functions with a return value                                              | ![ember][]             |     | 💡  |
-| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | disallow string interpolation in translation keys                                        | ![ember][]             |     |     |
-| [require-await-function](docs/rules/require-await-function.md)                     | enforce using `await` with calls to specified functions                                  | ![ember][]             | 🔧  |     |
-| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md)             | enforce using `assert.equal(...callCount, ...);` instead of `assert.ok(...calledOnce);`  | ![ember][] ![strict][] | 🔧  |     |
-| [use-ember-find](docs/rules/use-ember-find.md)                                     | require use of Ember's `find` helper instead of `jQuery` for selecting elements in tests | ![ember][]             | 🔧  |     |
+| Name                                                                               | Description                                                                              | 💼    | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------- | :---- | :-- | :-- |
+| [no-assert-ok-find](docs/rules/no-assert-ok-find.md)                               | disallow usage of `assert.ok(find(...))` as it will always pass                          | 🔥    |     | 💡  |
+| [no-handlebar-interpolation](docs/rules/no-handlebar-interpolation.md)             | disallow unsafe HTML in strings/hbs/translations                                         |       |     |     |
+| [no-missing-tests](docs/rules/no-missing-tests.md)                                 | disallow files without a corresponding test file                                         |       |     |     |
+| [no-restricted-files](docs/rules/no-restricted-files.md)                           | disallow files with a path matching a specific regexp                                    |       |     |     |
+| [no-test-return-value](docs/rules/no-test-return-value.md)                         | disallow test functions with a return value                                              | 🔥    |     | 💡  |
+| [no-translation-key-interpolation](docs/rules/no-translation-key-interpolation.md) | disallow string interpolation in translation keys                                        | 🔥    |     |     |
+| [require-await-function](docs/rules/require-await-function.md)                     | enforce using `await` with calls to specified functions                                  | 🔥    | 🔧  |     |
+| [use-call-count-test-assert](docs/rules/use-call-count-test-assert.md)             | enforce using `assert.equal(...callCount, ...);` instead of `assert.ok(...calledOnce);`  | 🔥 🔒 | 🔧  |     |
+| [use-ember-find](docs/rules/use-ember-find.md)                                     | require use of Ember's `find` helper instead of `jQuery` for selecting elements in tests | 🔥    | 🔧  |     |
 
-<!-- end rules list -->
-
-[ember]: https://img.shields.io/badge/-ember-orange.svg
-[strict]: https://img.shields.io/badge/-strict-black.svg
+<!-- end auto-generated rules list -->
 
 Note that we prefer to upstream our custom lint rules to third-party ESLint plugins whenever possible. The rules that still remain here are typically here because:
 

--- a/docs/rules/no-assert-ok-find.md
+++ b/docs/rules/no-assert-ok-find.md
@@ -1,10 +1,10 @@
 # Disallow usage of `assert.ok(find(...))` as it will always pass (`square/no-assert-ok-find`)
 
-💼 This rule is enabled in the following configs: `ember`.
+🔥 This rule is enabled in the `ember` [config](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).
 
-💡 This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions) that can be applied manually.
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Ember's old built-in `find('.selector')` acceptance test helper function always returns an array, even when no elements match. As a result, `assert.ok(find('.selector'))` will always pass, even if no elements are found, as an empty array is still truthy.
 

--- a/docs/rules/no-handlebar-interpolation.md
+++ b/docs/rules/no-handlebar-interpolation.md
@@ -1,6 +1,6 @@
 # Disallow unsafe HTML in strings/hbs/translations (`square/no-handlebar-interpolation`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule disallows "no-handlebar-interpolation" `{{{` in strings which is assumed to be used to insert unsafe HTML.
 

--- a/docs/rules/no-missing-tests.md
+++ b/docs/rules/no-missing-tests.md
@@ -1,6 +1,6 @@
 # Disallow files without a corresponding test file (`square/no-missing-tests`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Ensuring that files have corresponding test files can be helpful towards improving test coverage.
 

--- a/docs/rules/no-restricted-files.md
+++ b/docs/rules/no-restricted-files.md
@@ -1,6 +1,6 @@
 # Disallow files with a path matching a specific regexp (`square/no-restricted-files`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule can be used to disallow files at certain file paths.
 

--- a/docs/rules/no-test-return-value.md
+++ b/docs/rules/no-test-return-value.md
@@ -1,10 +1,10 @@
 # Disallow test functions with a return value (`square/no-test-return-value`)
 
-💼 This rule is enabled in the following configs: `ember`.
+🔥 This rule is enabled in the `ember` [config](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).
 
-💡 This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions) that can be applied manually.
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 For asynchronous tests, use async/await instead of returning a promise.
 

--- a/docs/rules/no-translation-key-interpolation.md
+++ b/docs/rules/no-translation-key-interpolation.md
@@ -1,8 +1,8 @@
 # Disallow string interpolation in translation keys (`square/no-translation-key-interpolation`)
 
-💼 This rule is enabled in the following configs: `ember`.
+🔥 This rule is enabled in the `ember` [config](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Using string interpolation for constructing translation keys makes it difficult to search for them to determine where and if they are used.
 

--- a/docs/rules/require-await-function.md
+++ b/docs/rules/require-await-function.md
@@ -1,10 +1,10 @@
 # Enforce using `await` with calls to specified functions (`square/require-await-function`)
 
-💼 This rule is enabled in the following configs: `ember`.
+🔥 This rule is enabled in the `ember` [config](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).
 
-🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Some functions are asynchronous and you may want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help you achieve this.
 

--- a/docs/rules/use-call-count-test-assert.md
+++ b/docs/rules/use-call-count-test-assert.md
@@ -1,10 +1,10 @@
 # Enforce using `assert.equal(...callCount, ...);` instead of `assert.ok(...calledOnce);` (`square/use-call-count-test-assert`)
 
-💼 This rule is enabled in the following configs: `ember`, `strict`.
+💼 This rule is enabled in the following [configs](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations): 🔥 `ember`, 🔒 `strict`.
 
-🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Using `callCount` rather than the other shortcut count helpers (such as `calledOnce`, `notCalled`) allows the test runner to show the actual number of times the spy was called.
 

--- a/docs/rules/use-ember-find.md
+++ b/docs/rules/use-ember-find.md
@@ -1,10 +1,10 @@
 # Require use of Ember's `find` helper instead of `jQuery` for selecting elements in tests (`square/use-ember-find`)
 
-💼 This rule is enabled in the following configs: `ember`.
+🔥 This rule is enabled in the `ember` [config](https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations).
 
-🔧 This rule is automatically fixable using the `--fix` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 It is preferred to use Ember test helpers like `find(selector)` instead of jQuery for selecting elements in tests.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint \"**/*.md\"",
-    "lint:eslint-docs": "npm-run-all update:eslint-docs && git diff --exit-code",
+    "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
@@ -37,7 +37,7 @@
     "preversion": "yarn test && yarn lint",
     "release": "release-it",
     "test": "nyc --all --check-coverage mocha --recursive tests",
-    "update:eslint-docs": "eslint-doc-generator"
+    "update:eslint-docs": "eslint-doc-generator --config-emoji ember,🔥 --url-configs \"https://github.com/square/eslint-plugin-square/blob/master/README.md#configurations\""
   },
   "prettier": "@square/prettier-config",
   "nyc": {
@@ -76,7 +76,7 @@
     "@types/requireindex": "^1.2.0",
     "@typescript-eslint/parser": "^5.40.0",
     "eslint": "^8.24.0",
-    "eslint-doc-generator": "^0.3.5",
+    "eslint-doc-generator": "^0.16.0",
     "eslint-plugin-eslint-plugin": "^5.0.6",
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,13 +2024,15 @@ eslint-config-prettier@^8.4.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
-eslint-doc-generator@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-0.3.5.tgz#e1828528faa3acd0f7dcc8ea52e2d5858decf89a"
-  integrity sha512-jNyIyGHDOxDeAA9WVZMYNoU3Rkzyp0eOBtWwave3N5eig14bE/UT96SYSKEwAFnmn9ipjHm5U4BjsBzs+t7dxw==
+eslint-doc-generator@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-0.16.0.tgz#97d69d891a1d399c76774c52f90a1988c9a4b26e"
+  integrity sha512-L6SQIKGP5TQsNDfDDv6n+VMh662BCYkDFK0aS4ey3+42DDMcs8NGHUQLTJkoLW2OSZvIM/lxHmZTjkDVXqLdFg==
   dependencies:
     "@typescript-eslint/utils" "^5.38.1"
+    camelcase "^7.0.0"
     commander "^9.4.0"
+    markdown-table "^3.0.2"
     type-fest "^3.0.0"
 
 eslint-import-resolver-node@^0.3.6:
@@ -3848,6 +3850,11 @@ markdown-it@13.0.1:
     linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
+
+markdown-table@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.2.tgz#9b59eb2c1b22fe71954a65ff512887065a7bb57c"
+  integrity sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==
 
 markdownlint-cli@^0.32.2:
   version "0.32.2"


### PR DESCRIPTION
Lots of improvements from `0.3.5` to https://github.com/bmish/eslint-doc-generator/releases/tag/v0.16.0.

For example, the legend for the rules list is now auto-generated.