### PR TITLE
Allow all unused vars with leading `_` in `typescript` config

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -18,7 +18,9 @@ module.exports = {
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-unused-vars': [
           'warn', // Warning used to align with @typescript-eslint/recommended
-          { argsIgnorePattern: '^_' }, // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
+
+          // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
+          { argsIgnorePattern: '^_', varsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
       },

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -20,7 +20,11 @@ module.exports = {
           'warn', // Warning used to align with @typescript-eslint/recommended
 
           // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
-          { argsIgnorePattern: '^_', varsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
+          {
+            argsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            destructuredArrayIgnorePattern: '^_',
+          },
         ],
         '@typescript-eslint/no-useless-constructor': 'error',
       },

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -22,8 +22,9 @@ module.exports = {
           // Pattern per Typescript spec: https://github.com/microsoft/TypeScript/issues/9458
           {
             argsIgnorePattern: '^_',
-            varsIgnorePattern: '^_',
+            caughtErrorsIgnorePattern: '^_',
             destructuredArrayIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
           },
         ],
         '@typescript-eslint/no-useless-constructor': 'error',


### PR DESCRIPTION
## What

- Adds `_*` as an ignore pattern for variables and array destructuring in no-unused-vars

## Why

We already allow `_` prefix for function arguments, and the same case could be made for other usages as well.

For a concrete example: Suppose I want to split a SemVer string but only care about the major version.

My options today are:

```ts
const [major] = semVer.split(".")
const [major, , ] = semVer.split(".")
const [major, /* minor, patch */] = semVer.split(".")
```

None of these read well and I'd like to be able to use `const [major, _minor, _patch] = semVer.split(".")`

In general though, with the _ prefix used to declare intention to allow an ignored variable we might as well expand that definition out.