### PR TITLE
Disable `filenames/match-exported` rule for generated `config/environment.d.ts` in `ember` config

### DIFF
--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -52,7 +52,6 @@ module.exports = {
     {
       files: [
         '**/{app,addon}/{components,controllers,routes,services}/**/*.{js,ts}',
-        '**/dummy/app/config/environment.d.ts',
       ],
       rules: {
         /**
@@ -65,6 +64,17 @@ module.exports = {
          * Produces a file with:
          *     export default class HelloWorldComponent extends Component {}
          * But this rule expects the class to be named "HelloWorld".
+         */
+        'filenames/match-exported': 'off',
+      },
+    },
+    {
+      files: [
+        '**/dummy/app/config/environment.d.ts',
+      ],
+      rules: {
+        /**
+         * environment.d.ts is generated from the ember-cli-typescript blueprint
          */
         'filenames/match-exported': 'off',
       },

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -52,6 +52,7 @@ module.exports = {
     {
       files: [
         '**/{app,addon}/{components,controllers,routes,services}/**/*.{js,ts}',
+        '**/dummy/app/config/environment.d.ts',
       ],
       rules: {
         /**

--- a/lib/config/ember.js
+++ b/lib/config/ember.js
@@ -69,9 +69,7 @@ module.exports = {
       },
     },
     {
-      files: [
-        '**/dummy/app/config/environment.d.ts',
-      ],
+      files: ['**/dummy/app/config/environment.d.ts'],
       rules: {
         /**
          * environment.d.ts is generated from the ember-cli-typescript blueprint


### PR DESCRIPTION
This rule triggers in CI after creating a new addon in Dashboard. [Example build part](https://kochiku-production-build-logs.s3.us-west-2.amazonaws.com/squareup/dashboard/build_6321230/part_322014409/attempt_277137685/stdout.log.gz?X-Amz-Expires=604800&X-Amz-Date=20221205T160212Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBPRFGE3IOTXUBCA%2F20221205%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=069d5b3769ded56a17e1120a7680ce05e0f9f39660ad750db6e428ca7b0e3b75).

```
/data/app/kochiku-worker/shared/build-partition/squareup/dashboard/frontend/@dashboard/ember-cli-csso/tests/dummy/app/config/environment.d.ts
  5:1  error  Filename 'environment' must match the exported and transformed name 'config'  filenames/match-exported
```


The generated code is defined [here](https://github.com/typed-ember/ember-cli-typescript/blob/bb6754670e7fe550516998e2965fff4097fcb2c3/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts) in ember-cli-typescript.

Related to https://github.com/square/eslint-plugin-square/pull/142