### PR TITLE
Warn on unused ESLint disable directives in `base` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,15 @@ Install alongside ESLint via yarn (or npm):
 yarn add --dev eslint eslint-plugin-square npm-run-all
 ```
 
-Edit your `.eslintrc.js` configuration file to extend one of the available configurations from this plugin and [detect unused disable directives](https://eslint.org/docs/latest/user-guide/configuring/rules#report-unused-eslint-disable-comments):
+Edit your `.eslintrc.js` configuration file to extend one of the available configurations from this plugin:
 
 ```js
 module.exports = {
-  reportUnusedDisableDirectives: true,
   extends: ['plugin:square/base'], // Or other configuration.
 };
 ```
 
-Add the relevant lint scripts in `package.json` with [npm-run-all](https://github.com/mysticatea/npm-run-all):
+Add the relevant lint scripts in `package.json` with [npm-run-all](https://github.com/mysticatea/npm-run-all) and include detection for [unused disable directives](https://eslint.org/docs/latest/user-guide/command-line-interface#--report-unused-disable-directives):
 
 ```json
 {

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -3,6 +3,7 @@
 // This configuration is intended for use with JavaScript applications.
 
 module.exports = {
+  reportUnusedDisableDirectives: true, // Warn on unused disable directives: https://eslint.org/docs/latest/user-guide/configuring/rules#report-unused-eslint-disable-comments
   extends: [
     'eslint:recommended',
     'plugin:eslint-comments/recommended',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint \"**/*.md\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
-    "lint:js": "eslint --cache .",
+    "lint:js": "eslint --report-unused-disable-directives --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
     "lint:package-json-sorting:fix": "sort-package-json package.json",


### PR DESCRIPTION
We already suggested this in the README, but we can actually ensure it's enabled for everybody in our shared configs.

Note that it is only possible to warn with this feature (erroring not possible yet, although I've written an RFC regarding this: https://github.com/eslint/rfcs/pull/100).

https://eslint.org/docs/latest/user-guide/configuring/rules#report-unused-eslint-disable-comments