### PR TITLE
Apply TypeScript rules to additional file types

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -154,7 +154,7 @@ module.exports = {
   overrides: [
     {
       // Tweaks for TypeScript files that we can apply for users even if they don't happen to use our `typescript` config.
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx', '*.mts', '*.cts'],
       extends: ['plugin:import/typescript'],
       rules: {
         // Last parameter allows for exporting from a .d.ts file

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -10,7 +10,7 @@ module.exports = {
   rules: {},
   overrides: [
     {
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx', '*.mts', '*.cts'],
       extends: ['plugin:@typescript-eslint/recommended'],
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/15#issuecomment-458224762

--- a/lib/rules/no-missing-tests.js
+++ b/lib/rules/no-missing-tests.js
@@ -58,8 +58,7 @@ module.exports = {
     const filename = context
       .getFilename()
       .replace(matchingLocation.filePath, '')
-      .replace('.js', '')
-      .replace('.ts', '');
+      .replace(/\.([jt]sx?|m[jt]s|c[jt]s)$/, '');
 
     const suffix = matchingLocation.hasTestSuffix ? '-test' : '';
     const possibleTestPaths = matchingLocation.testPaths.flatMap((testPath) => [

--- a/lib/utils/is-test-file.js
+++ b/lib/utils/is-test-file.js
@@ -5,7 +5,7 @@
  * @returns {boolean}
  */
 function isTestFile(fileName) {
-  return fileName.endsWith('-test.js') || fileName.endsWith('-test.ts');
+  return /-test\.([jt]sx?|m[jt]s|c[jt]s)$/.test(fileName);
 }
 
 module.exports = isTestFile;

--- a/tests/lib/utils/is-test-file.js
+++ b/tests/lib/utils/is-test-file.js
@@ -6,13 +6,27 @@ const assert = require('node:assert');
 describe('isTestFile', () => {
   it('detects test files', () => {
     assert.ok(isTestFile('some-test.js'));
+    assert.ok(isTestFile('some-test.jsx'));
     assert.ok(isTestFile('some-test.ts'));
+    assert.ok(isTestFile('some-test.tsx'));
+    assert.ok(isTestFile('some-test.mjs'));
+    assert.ok(isTestFile('some-test.cjs'));
+    assert.ok(isTestFile('some-test.mts'));
+    assert.ok(isTestFile('some-test.cts'));
   });
 
   it('does not detect other files', () => {
     assert.ok(!isTestFile('some-component.js'));
+    assert.ok(!isTestFile('some-component.jsx'));
+    assert.ok(!isTestFile('some-component.ts'));
+    assert.ok(!isTestFile('some-component.tsx'));
+    assert.ok(!isTestFile('some-file.mjs'));
+    assert.ok(!isTestFile('some-file.cjs'));
+    assert.ok(!isTestFile('some-file.mts'));
+    assert.ok(!isTestFile('some-file.cts'));
     assert.ok(!isTestFile('my-testing-component.js'));
     assert.ok(!isTestFile('router.js'));
     assert.ok(!isTestFile('my-test.html'));
+    assert.ok(!isTestFile('.js.txt'));
   });
 });


### PR DESCRIPTION
Currently, TypeScript-specific rules in the `typescript` config apply to `.ts` files but not `.tsx` files. This PR simply adds the `.tsx` extension to the `files` array. 