### PR TITLE
feat!: drop Node v14 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,6 @@ module.exports = {
           'https://github.com/square/eslint-plugin-square/tree/master/docs/rules/{{name}}.md',
       },
     ],
-
-    'unicorn/prefer-node-protocol': 'error', // TODO: Move this to `base` config once we drop support for Node 14 entirely.
   },
   overrides: [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin contains lint rule definitions and configurations for [ESLint](http:
 ## Requirements
 
 - [ESLint](https://eslint.org/) `>= 8.18.0`
-- [Node.js](https://nodejs.org/) `^14.18.0 || ^16.0.0 || >= 18.0.0`
+- [Node.js](https://nodejs.org/) `^16.0.0 || >= 18.0.0`
 
 ## Usage
 

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -144,7 +144,6 @@ module.exports = {
     'unicorn/prefer-dom-node-remove': 'off', // This incorrectly autofixes `remove()` on non-DOM-nodes.
     'unicorn/prefer-dom-node-text-content': 'off', // The autofixer can be unsafe.
     'unicorn/prefer-module': 'off', // Not ready for this yet.
-    'unicorn/prefer-node-protocol': 'off', // TODO: Enable once we drop support for Node 14 entirely.
     'unicorn/prefer-prototype-methods': 'off', // Too noisy for now.
     'unicorn/prefer-query-selector': 'off', // The autofixer can be unsafe.
     'unicorn/prefer-switch': 'off', // Too aggressive for now.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "eslint": ">= 8.18.0"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.0.0 || >= 18.0.0"
+    "node": "^16.0.0 || >= 18.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
EOL 2023-04-30. blocking dependency upgrades (like #882 which will address #880)

https://github.com/nodejs/release#end-of-life-releases