### PR TITLE
Fix no-missing-tests bug when multiple matching options are present

### DIFF
--- a/lib/rules/no-missing-tests.js
+++ b/lib/rules/no-missing-tests.js
@@ -46,32 +46,38 @@ module.exports = {
   create(context) {
     /** @type {{filePath:string,testPaths:string[],hasTestSuffix?:boolean}[]} */
     const config = context.options[0];
-    const matchingLocation = config.find((location) =>
+
+    /** @type {{filePath:string,testPaths:string[],hasTestSuffix?:boolean}[]} */
+    const matchingLocations = config.filter((location) =>
       context.getFilename().includes(location.filePath)
     );
 
-    if (!matchingLocation) {
+    if (matchingLocations.length === 0) {
       // Rule configuration does not apply to this file.
       return {};
     }
 
-    const filename = context
-      .getFilename()
-      .replace(matchingLocation.filePath, '')
-      .replace(/\.([jt]sx?|m[jt]s|c[jt]s)$/, '');
+    for (const matchingLocation of matchingLocations) {
+      const filename = context
+        .getFilename()
+        .replace(matchingLocation.filePath, '')
+        .replace(/\.([jt]sx?|m[jt]s|c[jt]s)$/, '');
 
-    const suffix = matchingLocation.hasTestSuffix ? '-test' : '';
-    const possibleTestPaths = matchingLocation.testPaths.flatMap((testPath) => [
-      path.join(testPath, `${filename}${suffix}.js`),
-      path.join(testPath, `${filename}${suffix}.ts`),
-    ]);
+      const suffix = matchingLocation.hasTestSuffix ? '-test' : '';
+      const possibleTestPaths = matchingLocation.testPaths.flatMap(
+        (testPath) => [
+          path.join(testPath, `${filename}${suffix}.js`),
+          path.join(testPath, `${filename}${suffix}.ts`),
+        ]
+      );
 
-    const foundMatchingTest = possibleTestPaths.some((possibleTestPath) =>
-      existsSync(possibleTestPath)
-    );
-    if (foundMatchingTest) {
-      // File has corresponding test file.
-      return {};
+      const foundMatchingTest = possibleTestPaths.some((possibleTestPath) =>
+        existsSync(possibleTestPath)
+      );
+      if (foundMatchingTest) {
+        // File has corresponding test file.
+        return {};
+      }
     }
 
     return {

--- a/tests/lib/rules/no-missing-tests.js
+++ b/tests/lib/rules/no-missing-tests.js
@@ -33,6 +33,41 @@ ruleTester.run('no-missing-tests', rule, {
       ],
     },
     {
+      filename: RULE_FILE, // This file matches multiple entries in options
+      code: 'var x = 123;',
+      options: [
+        [
+          // Consider a folder structure like
+          //   lib/
+          //     widget/
+          //     widgets/
+          //   test/
+          //     widget/
+          //     widgets/
+          // with options configured for both pairs of folders. They will both
+          // match, but if our file is in `lib/widgets`, we won't find a test
+          // in the `test/widget` folder. We still want to pass the file if
+          // if has a test in `test/widgets` folder - any one option matching is enough.
+          {
+            // this option's filePath will match, but there will be
+            // no test at the test path. If this were the only option,
+            // the rule would fail, but because the second option does
+            // have a test, we still pass this case.
+            filePath: RULES_LIB_PATH.slice(0, -1),
+            testPaths: [RULES_TESTS_PATH.slice(0, -1)],
+            hasTestSuffix: false,
+          },
+          {
+            // this option's filePath matches, and there is a test
+            // at the test path.
+            filePath: RULES_LIB_PATH,
+            testPaths: [RULES_TESTS_PATH],
+            hasTestSuffix: false,
+          },
+        ],
+      ],
+    },
+    {
       filename: RANDOM_FILE, // This file is not covered by the rule configuration and should be ignored.
       code: 'var x = 123;',
       options: [


### PR DESCRIPTION
Currently, if multiple options that match the `filePath` of a file are present, only the first option's testPaths are considered. We want to accept a test from any matching option.

 - First commit adds a reproduction test case
 - Second commit adds a fix