### PR TITLE
docs: add note on ESLint configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Install alongside ESLint via yarn (or npm):
 yarn add --dev eslint eslint-plugin-square npm-run-all
 ```
 
-Edit your `.eslintrc.js` configuration file to extend one of the available configurations from this plugin:
+If you're creating a new ESLint configuration, refer to ESLint's [documentation](https://eslint.org/docs/latest/use/configure/configuration-files) to determine the correct file format for your project. For example, ESM projects with `"type": "module"` in their package.json should use an `.eslintrc.cjs` file format instead of `.eslintrc.js`.
+
+Once you have an ESLint configuration file, add this plugin to your `extends` configuration:
 
 ```js
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add --dev eslint eslint-plugin-square npm-run-all
 
 If you're creating a new ESLint configuration, refer to ESLint's [documentation](https://eslint.org/docs/latest/use/configure/configuration-files) to determine the correct file format for your project. For example, ESM projects with `"type": "module"` in their package.json should use an `.eslintrc.cjs` file format instead of `.eslintrc.js`.
 
-Once you have an ESLint configuration file, add this plugin to your `extends` configuration:
+Once you have an ESLint configuration file, add this plugin to your `extends` property:
 
 ```js
 module.exports = {


### PR DESCRIPTION
ESM projects need to use a `.eslintrc.cjs` file for configuration. The current note only mentions `.eslintrc.js` which was causing some confusion and errors for people creating new ESM projects. 