### PR TITLE
docs: add release bypass instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,10 +6,10 @@ To release a new version, just go to the current temporary release PR, review if
 
 Once it's merged, the release will be automatically published to NPM, with the GitHub Release and tags being created too.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > The Release PRs don't run any CI checks because it's an automation that uses the `github-action` bot.
 > For now, when we are ready to release, we need to check the `Merge without waiting for requirementes to be met (bypass rules)` and merge.
-> That's because the CI won't have any runs. Since the Release PR has only CHANGELOGs and the package.json bump, it should be harmless. 
+> That's because the CI won't have any runs. Since the Release PR has only CHANGELOGs and the package.json bump, it should be harmless.
 
 ## Temporary Release PRs
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,11 @@ To release a new version, just go to the current temporary release PR, review if
 
 Once it's merged, the release will be automatically published to NPM, with the GitHub Release and tags being created too.
 
+> [!IMPORTANT]  
+> The Release PRs don't run any CI checks because it's an automation that uses the `github-action` bot.
+> For now, when we are ready to release, we need to check the `Merge without waiting for requirementes to be met (bypass rules)` and merge.
+> That's because the CI won't have any runs. Since the Release PR has only CHANGELOGs and the package.json bump, it should be harmless. 
+
 ## Temporary Release PRs
 
 A single temporary PR is created once the CI detects relevant pushes (feat, fix, etc.).


### PR DESCRIPTION
Add bypass instructions to release.

This should be temporary while we evolve the Releaser to use an App to open the Release PR.