### PR TITLE
chore: update release process to have the GH App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: block/ospo/actions/releaser@main
         with:
+          block-releaser-app-id: ${{ secrets.BLOCK_RELEASER_APP_ID }}
+          block-releaser-private-key: ${{ secrets.BLOCK_RELEASER_APP_PRIVATE_KEY }}
           release-type: node
           node-version: 20
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,6 @@ To release a new version, just go to the current temporary release PR, review if
 
 Once it's merged, the release will be automatically published to NPM, with the GitHub Release and tags being created too.
 
-> [!IMPORTANT]
-> The Release PRs don't run any CI checks because it's an automation that uses the `github-action` bot.
-> For now, when we are ready to release, we need to check the `Merge without waiting for requirementes to be met (bypass rules)` and merge.
-> That's because the CI won't have any runs. Since the Release PR has only CHANGELOGs and the package.json bump, it should be harmless.
-
 ## Temporary Release PRs
 
 A single temporary PR is created once the CI detects relevant pushes (feat, fix, etc.).


### PR DESCRIPTION
With the GH App we won't need to bypass the CI check anymore, so I removed temporary release PR bypass instructions from RELEASE.md and added necessary secrets for the Block Releaser in the release workflow configuration.
